### PR TITLE
LIBITD-439. Restrict CRUD functions on personnel requests based on user roles

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@ class ApplicationController < ActionController::Base
   include CasHelper
   include Pundit
   before_action :authenticate
+  after_action :verify_authorized, except: :index
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -28,6 +28,7 @@ class ContractorRequestsController < ApplicationController
 
   # GET /contractor_requests/1/edit
   def edit
+    authorize @contractor_request
   end
 
   # POST /contractor_requests

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -35,7 +35,8 @@ class ContractorRequestsController < ApplicationController
   # POST /contractor_requests.json
   def create
     @contractor_request = ContractorRequest.new(contractor_request_params)
-
+    authorize @contractor_request
+    
     respond_to do |format|
       if @contractor_request.save
         format.html { redirect_to @contractor_request, notice: 'Contractor request was successfully created.' }

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -23,6 +23,7 @@ class ContractorRequestsController < ApplicationController
 
   # GET /contractor_requests/new
   def new
+    authorize ContractorRequest
     @contractor_request = ContractorRequest.new
   end
 

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -18,6 +18,7 @@ class ContractorRequestsController < ApplicationController
   # GET /contractor_requests/1
   # GET /contractor_requests/1.json
   def show
+    authorize @contractor_request
   end
 
   # GET /contractor_requests/new

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -50,6 +50,7 @@ class ContractorRequestsController < ApplicationController
   # PATCH/PUT /contractor_requests/1
   # PATCH/PUT /contractor_requests/1.json
   def update
+    authorize @contractor_request
     respond_to do |format|
       if @contractor_request.update(contractor_request_params)
         format.html { redirect_to @contractor_request, notice: 'Contractor request was successfully updated.' }
@@ -64,6 +65,7 @@ class ContractorRequestsController < ApplicationController
   # DELETE /contractor_requests/1
   # DELETE /contractor_requests/1.json
   def destroy
+    authorize @contractor_request
     @contractor_request.destroy
     respond_to do |format|
       format.html { redirect_to contractor_requests_url, notice: 'Contractor request was successfully destroyed.' }

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -33,10 +33,11 @@ class ContractorRequestsController < ApplicationController
 
   # POST /contractor_requests
   # POST /contractor_requests.json
+  # rubocop:disable Metrics/MethodLength
   def create
     @contractor_request = ContractorRequest.new(contractor_request_params)
     authorize @contractor_request
-    
+
     respond_to do |format|
       if @contractor_request.save
         format.html { redirect_to @contractor_request, notice: 'Contractor request was successfully created.' }

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -1,6 +1,7 @@
 class ContractorRequestsController < ApplicationController
   include PersonnelRequestController
   before_action :set_contractor_request, only: [:show, :edit, :update, :destroy]
+  after_action :verify_policy_scoped, only: :index
 
   # GET /contractor_requests
   # GET /contractor_requests.json

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -18,6 +18,7 @@ class LaborRequestsController < ApplicationController
   # GET /labor_requests/1
   # GET /labor_requests/1.json
   def show
+    authorize @labor_request
   end
 
   # GET /labor_requests/new

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -50,6 +50,7 @@ class LaborRequestsController < ApplicationController
   # PATCH/PUT /labor_requests/1
   # PATCH/PUT /labor_requests/1.json
   def update
+    authorize @labor_request
     respond_to do |format|
       if @labor_request.update(labor_request_params)
         format.html { redirect_to @labor_request, notice: 'Labor request was successfully updated.' }
@@ -64,6 +65,7 @@ class LaborRequestsController < ApplicationController
   # DELETE /labor_requests/1
   # DELETE /labor_requests/1.json
   def destroy
+    authorize @labor_request
     @labor_request.destroy
     respond_to do |format|
       format.html { redirect_to labor_requests_url, notice: 'Labor request was successfully destroyed.' }

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -1,6 +1,7 @@
 class LaborRequestsController < ApplicationController
   include PersonnelRequestController
   before_action :set_labor_request, only: [:show, :edit, :update, :destroy]
+  after_action :verify_policy_scoped, only: :index
 
   # GET /labor_requests
   # GET /labor_requests.json

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -33,10 +33,11 @@ class LaborRequestsController < ApplicationController
 
   # POST /labor_requests
   # POST /labor_requests.json
+  # rubocop:disable Metrics/MethodLength
   def create
     @labor_request = LaborRequest.new(labor_request_params)
     authorize @labor_request
-    
+
     respond_to do |format|
       if @labor_request.save
         format.html { redirect_to @labor_request, notice: 'Labor request was successfully created.' }

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -35,7 +35,8 @@ class LaborRequestsController < ApplicationController
   # POST /labor_requests.json
   def create
     @labor_request = LaborRequest.new(labor_request_params)
-
+    authorize @labor_request
+    
     respond_to do |format|
       if @labor_request.save
         format.html { redirect_to @labor_request, notice: 'Labor request was successfully created.' }

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -23,6 +23,7 @@ class LaborRequestsController < ApplicationController
 
   # GET /labor_requests/new
   def new
+    authorize LaborRequest
     @labor_request = LaborRequest.new
   end
 

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -28,6 +28,7 @@ class LaborRequestsController < ApplicationController
 
   # GET /labor_requests/1/edit
   def edit
+    authorize @labor_request
   end
 
   # POST /labor_requests

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -1,7 +1,8 @@
 class StaffRequestsController < ApplicationController
   include PersonnelRequestController
   before_action :set_staff_request, only: [:show, :edit, :update, :destroy]
-
+  after_action :verify_policy_scoped, only: :index
+  
   # GET /staff_requests
   # GET /staff_requests.json
   def index

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -18,6 +18,7 @@ class StaffRequestsController < ApplicationController
   # GET /staff_requests/1
   # GET /staff_requests/1.json
   def show
+    authorize @staff_request
   end
 
   # GET /staff_requests/new

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -50,6 +50,7 @@ class StaffRequestsController < ApplicationController
   # PATCH/PUT /staff_requests/1
   # PATCH/PUT /staff_requests/1.json
   def update
+    authorize @staff_request
     respond_to do |format|
       if @staff_request.update(staff_request_params)
         format.html { redirect_to @staff_request, notice: 'Staff request was successfully updated.' }
@@ -64,6 +65,7 @@ class StaffRequestsController < ApplicationController
   # DELETE /staff_requests/1
   # DELETE /staff_requests/1.json
   def destroy
+    authorize @staff_request
     @staff_request.destroy
     respond_to do |format|
       format.html { redirect_to staff_requests_url, notice: 'Staff request was successfully destroyed.' }

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -35,7 +35,8 @@ class StaffRequestsController < ApplicationController
   # POST /staff_requests.json
   def create
     @staff_request = StaffRequest.new(staff_request_params)
-
+    authorize @staff_request
+    
     respond_to do |format|
       if @staff_request.save
         format.html { redirect_to @staff_request, notice: 'Staff request was successfully created.' }

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -2,7 +2,7 @@ class StaffRequestsController < ApplicationController
   include PersonnelRequestController
   before_action :set_staff_request, only: [:show, :edit, :update, :destroy]
   after_action :verify_policy_scoped, only: :index
-  
+
   # GET /staff_requests
   # GET /staff_requests.json
   def index

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -28,6 +28,7 @@ class StaffRequestsController < ApplicationController
 
   # GET /staff_requests/1/edit
   def edit
+    authorize @staff_request
   end
 
   # POST /staff_requests

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -33,10 +33,11 @@ class StaffRequestsController < ApplicationController
 
   # POST /staff_requests
   # POST /staff_requests.json
+  # rubocop:disable Metrics/MethodLength
   def create
     @staff_request = StaffRequest.new(staff_request_params)
     authorize @staff_request
-    
+
     respond_to do |format|
       if @staff_request.save
         format.html { redirect_to @staff_request, notice: 'Staff request was successfully created.' }

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -23,6 +23,7 @@ class StaffRequestsController < ApplicationController
 
   # GET /staff_requests/new
   def new
+    authorize StaffRequest
     @staff_request = StaffRequest.new
   end
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,8 +4,25 @@ class User < ActiveRecord::Base
   validates :cas_directory_id, presence: true, uniqueness: { case_sensitive: false }
   validates :name, presence: true
 
-  # Returns true if the current user is an admin, false otherwise.
+  # Returns true if this user has an Admin role, false otherwise.
   def admin?
-    Role.where(user: self).where(role_type: RoleType.find_by_code('admin')).any?
+    roles(RoleType.find_by_code('admin')).any?
+  end
+
+  # Returns true if this user has a Division role, false otherwise.
+  def division?
+    roles(RoleType.find_by_code('division')).any?
+  end
+
+  # Returns an array of Roles for this user. Can optionally specify the RoleType
+  # of roles to return.
+  #
+  # If the user has no roles, an empty array is returned.
+  def roles(role_type = nil)
+    if role_type.nil?
+      return roles = Role.where(user: self).to_ary
+    else
+      return roles = Role.where(user: self).where(role_type: role_type).to_ary
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,10 +19,8 @@ class User < ActiveRecord::Base
   #
   # If the user has no roles, an empty array is returned.
   def roles(role_type = nil)
-    if role_type.nil?
-      return roles = Role.where(user: self).to_ary
-    else
-      return roles = Role.where(user: self).where(role_type: role_type).to_ary
-    end
+    return Role.where(user: self).to_ary if role_type.nil?
+
+    Role.where(user: self).where(role_type: role_type).to_ary
   end
 end

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -17,7 +17,7 @@ class PersonnelRequestPolicy < ApplicationPolicy
   end
 
   def destroy?
-    true
+    destroy_allowed_by_role?(user, record)
   end
 
   # Returns an array of Departments in the division
@@ -105,8 +105,8 @@ class PersonnelRequestPolicy < ApplicationPolicy
 
     # Returns true if a user is allowed to destroy the given record, false
     # otherwise.
-    def destroy_allowed_by_role?
-      true
+    def destroy_allowed_by_role?(user, record)
+      return update_allowed_by_role?(user, record)
     end
 
   # Limits the scope of returned results based on role

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -12,6 +12,10 @@ class PersonnelRequestPolicy < ApplicationPolicy
     create_allowed_by_role?(user, record)
   end
 
+  def new?
+    new_allowed_by_role?(user)
+  end
+
   def update?
     update_allowed_by_role?(user, record)
   end
@@ -83,6 +87,12 @@ class PersonnelRequestPolicy < ApplicationPolicy
     # otherwise.
     def create_allowed_by_role?(user, record)
       update_allowed_by_role?(user, record)
+    end
+
+    # Returns true if a user is allowed to generate new records, false
+    # otherwise.
+    def new_allowed_by_role?(user)
+      return true if user.roles.any?
     end
 
     # Returns true if a user is allowed to edit the given record, false

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -12,16 +12,8 @@ class PersonnelRequestPolicy < ApplicationPolicy
     true
   end
 
-  def new?
-    create?
-  end
-
   def update?
-    edit?
-  end
-
-  def edit?
-    true
+    update_allowed_by_role?(user, record)
   end
 
   def destroy?
@@ -77,12 +69,12 @@ class PersonnelRequestPolicy < ApplicationPolicy
       return true if user.division?
 
       # Department role can see record if in department
-      user_departments = PersonnelRequestPolicy.allowed_departments(user)
-      return true if user_departments.any? && user_departments.include?(record.department)
+      allowed_departments = PersonnelRequestPolicy.allowed_departments(user)
+      return true if allowed_departments.include?(record.department)
 
       # Unit role can see record if in unit
-      user_units = PersonnelRequestPolicy.allowed_units(user)
-      return true if !user_units.nil? && user_units.include?(record.unit)
+      allowed_units = PersonnelRequestPolicy.allowed_units(user)
+      return true if allowed_units.include?(record.unit)
 
       false
     end
@@ -95,17 +87,18 @@ class PersonnelRequestPolicy < ApplicationPolicy
 
     # Returns true if a user is allowed to edit the given record, false
     # otherwise.
-    def edit_allowed_by_role?(user, record)
+    def update_allowed_by_role?(user, record)
       return false if user.roles.empty?
 
       return true if user.admin?
 
-      # Users with division or department roles can edit if record is in
-      # an allowed departmentDivision role and can edit entries on departments in division
-      return true if PersonnelRequestPolicy.allowed_departments(user).include?(record.department)
+      # Division and Department role can edit record if in department
+      allowed_departments = PersonnelRequestPolicy.allowed_departments(user)
+      return true if allowed_departments.include?(record.department)
 
-      # Users with unit role can see record if in unit
-      return true if PersonnelRequestPolicy.allowed_units(user).include?(record.unit)
+      # Unit role can see record if in unit
+      allowed_units = PersonnelRequestPolicy.allowed_units(user)
+      return true if allowed_units.include?(record.unit)
 
       false
     end

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -9,7 +9,7 @@ class PersonnelRequestPolicy < ApplicationPolicy
   end
 
   def create?
-    true
+    create_allowed_by_role?(user, record)
   end
 
   def update?
@@ -81,8 +81,8 @@ class PersonnelRequestPolicy < ApplicationPolicy
 
     # Returns true if a user is allowed to create the given record, false
     # otherwise.
-    def create_allowed_by_role?
-      true
+    def create_allowed_by_role?(user, record)
+      update_allowed_by_role?(user, record)
     end
 
     # Returns true if a user is allowed to edit the given record, false

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -106,7 +106,7 @@ class PersonnelRequestPolicy < ApplicationPolicy
     # Returns true if a user is allowed to destroy the given record, false
     # otherwise.
     def destroy_allowed_by_role?(user, record)
-      return update_allowed_by_role?(user, record)
+      update_allowed_by_role?(user, record)
     end
 
   # Limits the scope of returned results based on role

--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -4,19 +4,165 @@ class PersonnelRequestPolicy < ApplicationPolicy
     true
   end
 
+  def show?
+    show_allowed_by_role?(user, record)
+  end
+
+  def create?
+    return true
+#    create_allowed_by_role?(user)
+  end
+
+  def new?
+    create?
+  end
+
+  def update?
+    edit?
+  end
+
+  def edit?
+    return true
+#    edit_allowed_by_role?(user, record)
+  end
+
+  def destroy?
+    return true
+#    destroy_allowed_by_role?(user, record)
+  end
+
+  private
+
+#    def self.user_divisions(user_roles)
+#      user_roles.where('role_type_id = ?', RoleType.find_by_code('division'))
+#    end
+
+    # Returns an array of Departments in the division
+    #
+    # division - the Division to return the departments of
+    def self.departments_in_division(division)
+      Department.where(division_id: division)
+    end
+
+    # Returns an array of Departments the user's roles allow access to
+    def self.allowed_departments(user)
+      allowed_departments = []
+
+      division_roles = user.roles(RoleType.find_by_code('division'))
+      division_roles.each do |r|
+        depts_in_division = departments_in_division(r.division)
+        allowed_departments += depts_in_division
+      end
+
+      department_roles = user.roles(RoleType.find_by_code('department'))
+      department_roles.each do |r|
+        allowed_departments << r.department
+      end
+
+#      unit_roles = user.roles(RoleType.find_by_code('unit'))
+#      unit_roles.each do |r|
+#        allowed_departments << r.unit.department
+#      end
+
+      allowed_departments.uniq
+    end
+
+    # Returns an array of Units the user's roles allow access to
+    def self.allowed_units(user)
+      allowed_units = []
+      unit_roles = user.roles(RoleType.find_by_code('unit'))
+      unit_roles.each do |r|
+        allowed_units << r.unit
+      end
+      allowed_units
+    end
+
+#    def self.departments_in_division(user_divisions)
+#      Department.where(division_id: user_divisions)
+#    end
+
+#    def self.user_departments(user_roles)
+#      user_roles.where('role_type_id = ?', RoleType.find_by_code('department')).select('department_id')
+#    end
+#
+#    def self.user_units(user_roles)
+#      user_roles.where('role_type_id = ?', RoleType.find_by_code('unit')).select('unit_id')
+#    end
+
+    # Returns true if a user is allowed to show the given record, false
+    # otherwise.
+    def show_allowed_by_role?(user, record)
+      return true if user.admin?
+
+      user_roles = Role.where(user_id: user)
+      return false if user.roles.empty?
+
+      # Division role can see all entries
+      return true if user.division?
+
+      # Department role can see record if in department
+      user_departments = PersonnelRequestPolicy.allowed_departments(user)#PersonnelRequestPolicy.user_departments(user_roles)
+      return true if user_departments.any? && user_departments.include?(record.department)
+
+      # Unit role can see record if in unit
+      user_units = PersonnelRequestPolicy.allowed_units(user)
+      return true if !user_units.nil? && user_units.include?(record.unit)
+
+      return false
+    end
+
+    # Returns true if a user is allowed to create the given record, false
+    # otherwise.
+    def create_allowed_by_role?(user, record)
+      return true if user.admin?
+
+      user_roles = Role.where('user_id = ?', user)
+      division_departments = PersonnelRequestPolicy.departments_in_division(user)
+
+      if division_departments.any?
+        return true if division_departments.where(id: record.department.id).any?
+      end
+    end
+
+
+    # Returns true if a user is allowed to edit the given record, false
+    # otherwise.
+    def edit_allowed_by_role?(user, record)
+      return true if user.admin?
+
+      user_roles = Role.where('user_id = ?', user)
+      division_departments = PersonnelRequestPolicy.departments_in_division(user)
+
+      if division_departments.any?
+        return true if division_departments.where(id: record.department.id).any?
+      end
+    end
+
+    # Returns true if a user is allowed to destroy the given record, false
+    # otherwise.
+    def destroy_allowed_by_role?(user, record)
+      return true if user.admin?
+
+      user_roles = Role.where('user_id = ?', user)
+      division_departments = PersonnelRequestPolicy.departments_in_division(user)
+
+      if division_departments.any?
+        return true if division_departments.where(id: record.department.id).any?
+      end
+    end
+
+
   # Limits the scope of returned results based on role
   class Scope < Scope
     # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity
     def resolve
-      user_roles = Role.where('user_id = ?', user)
-      if admin?(user_roles)
+      if user.admin?
         # Admin always sees everything
         return scope
       end
 
       # Division scope
-      user_divisions = user_divisions(user_roles)
-      unless user_divisions.empty?
+      if user.division?
         # Users with Division role can see everything
         return scope
       end
@@ -25,7 +171,7 @@ class PersonnelRequestPolicy < ApplicationPolicy
       union_results = scope.none
 
       # Department scope
-      user_departments = user_departments(user_roles)
+      user_departments = PersonnelRequestPolicy.allowed_departments(user)#roles(RoleType.find_by_code('department')) #PersonnelRequestPolicy.user_departments(user_roles)
       department_results = scope.none
       unless user_departments.empty?
         department_results = scope.where(department_id: user_departments)
@@ -40,7 +186,7 @@ class PersonnelRequestPolicy < ApplicationPolicy
       end
 
       # Unit scope
-      user_units = user_units(user_roles)
+      user_units = PersonnelRequestPolicy.allowed_units(user)#PersonnelRequestPolicy.user_units(user_roles)
       unit_results = scope.none
       unless user_units.empty?
         unit_results = scope.where(unit_id: user_units)
@@ -69,27 +215,5 @@ class PersonnelRequestPolicy < ApplicationPolicy
       end
       union_results
     end
-
-    private
-
-      def admin?(user_roles)
-        user_roles.where('role_type_id = ?', RoleType.find_by_code('admin')).any?
-      end
-
-      def user_divisions(user_roles)
-        user_roles.where('role_type_id = ?', RoleType.find_by_code('division'))
-      end
-
-      def departments_in_division(user_divisions)
-        Department.where(division_id: user_divisions)
-      end
-
-      def user_departments(user_roles)
-        user_roles.where('role_type_id = ?', RoleType.find_by_code('department')).select('department_id')
-      end
-
-      def user_units(user_roles)
-        user_roles.where('role_type_id = ?', RoleType.find_by_code('unit')).select('unit_id')
-      end
   end
 end

--- a/app/views/shared/_index_action_buttons.erb
+++ b/app/views/shared/_index_action_buttons.erb
@@ -9,8 +9,10 @@
 
 <div class="btn-toolbar">
   <% if defined?(pagination_object) && pagination_object.respond_to?('total_pages') then %>
-    <div class="btn-group"><%=  will_paginate(:renderer => BootstrapPagination::Rails) %></div>
+    <div class="btn-group"><%= will_paginate(:renderer => BootstrapPagination::Rails) %></div>
   <% end %>
 
-  <div class="btn-group"><%= link_to 'New', new_polymorphic_path(model_type), class: 'btn btn-success' %></div>
+  <% if policy(model_type).new? %>
+    <div class="btn-group"><%= link_to 'New', new_polymorphic_path(model_type), class: 'btn btn-success', :id => 'toolbar_new' %></div>
+  <% end %>    
 </div>

--- a/app/views/shared/_show_action_buttons.erb
+++ b/app/views/shared/_show_action_buttons.erb
@@ -2,8 +2,10 @@
 # Displays "Edit" and "List All" buttons, intended for "Show" pages 
 %>
 
-<%= link_to 'Edit', edit_polymorphic_path(object), class: "btn btn-info" %>
+<% if policy(object).edit? %>
+  <%= link_to 'Edit', edit_polymorphic_path(object), class: "btn btn-info", :id => 'button_edit' %>
+<% end %>
 <% if policy(object).index? %>
-  <%= link_to 'List All', polymorphic_path(object.class), class: "btn btn-default"%>
+  <%= link_to 'List All', polymorphic_path(object.class), class: "btn btn-default" %>
 <% end %>
 

--- a/app/views/shared/_table_action_buttons.erb
+++ b/app/views/shared/_table_action_buttons.erb
@@ -1,19 +1,25 @@
 <td headers="actions">
   <span style="white-space: nowrap">
-    <%= link_to object, class: "btn btn-default", title: "Details" do %>
-      <i class="glyphicon glyphicon-option-horizontal"></i>
+    <% if policy(object).show? %>
+      <%= link_to object, class: "btn btn-default", title: "Details" do %>
+        <i class="glyphicon glyphicon-option-horizontal"></i>
+      <% end %>
     <% end %>
-    <%= link_to edit_polymorphic_path(object), class: "btn btn-info", title: "Edit" do %>
-      <i class="glyphicon glyphicon-pencil"></i>
+    <% if policy(object).edit? %>
+      <%= link_to edit_polymorphic_path(object), class: "btn btn-info", title: "Edit" do %>
+        <i class="glyphicon glyphicon-pencil"></i>
+      <% end %>
     <% end %>
 
-    <% if object.respond_to?('allow_delete?') && !object.allow_delete? %>
-      <button class="btn btn-danger delete" disabled="disabled"><i class="glyphicon glyphicon-trash"></i></button>
-    <% else %>
-      <%= link_to object, method: :delete,
-            data: { confirm: 'Are you sure?' }, class: "btn btn-danger delete", title: "Delete" do %>
-        <i class="glyphicon glyphicon-trash"></i>
-      <% end %>
-    <% end %>    
+    <% if policy(object).destroy? %>
+      <% if object.respond_to?('allow_delete?') && !object.allow_delete? %>
+        <button class="btn btn-danger delete" disabled="disabled"><i class="glyphicon glyphicon-trash"></i></button>
+      <% else %>
+        <%= link_to object, method: :delete,
+              data: { confirm: 'Are you sure?' }, class: "btn btn-danger delete", title: "Delete" do %>
+          <i class="glyphicon glyphicon-trash"></i>
+        <% end %>
+      <% end %>    
+    <% end %>
   </span>
 </td> 

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -17,4 +17,32 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"Edit" button should only be shown if policy allows edit' do
+    @division1 = divisions_with_records[0]
+    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
+    Role.create!(user: @division1_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: @division1)
+
+    run_as_user(@division1_user) do
+      contractor_requests_all = ContractorRequest.all
+
+      contractor_requests_all.each do |r|
+        get contractor_request_path(r)
+        if Pundit.policy!(@division1_user, r).edit?
+          assert_select "[id='button_edit']", 1,
+                        "'#{@division1.code}' user could NOT edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        else
+          assert_select "[id='button_edit']", 0,
+                        "'#{@division1.code}' user could edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        end
+      end
+    end
+
+    Role.destroy_all(user: @division1_user)
+    @division1_user.destroy!
+  end
 end

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -52,4 +52,18 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"New" button should only be shown for users with roles' do
+    run_as_user(users(:test_admin)) do
+      get contractor_requests_path
+      assert_select "[id='toolbar_new']"
+    end
+
+    no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
+    run_as_user(no_role_user) do
+      get contractor_requests_path
+      assert_select "[id='toolbar_new']", 0
+    end
+    no_role_user.destroy!
+  end
 end

--- a/test/integration/labor_requests_edit_test.rb
+++ b/test/integration/labor_requests_edit_test.rb
@@ -17,4 +17,32 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"Edit" button should only be shown if policy allows edit' do
+    @division1 = divisions_with_records[0]
+    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
+    Role.create!(user: @division1_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: @division1)
+
+    run_as_user(@division1_user) do
+      labor_requests_all = LaborRequest.all
+
+      labor_requests_all.each do |r|
+        get labor_request_path(r)
+        if Pundit.policy!(@division1_user, r).edit?
+          assert_select "[id='button_edit']", 1,
+                        "'#{@division1.code}' user could NOT edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        else
+          assert_select "[id='button_edit']", 0,
+                        "'#{@division1.code}' user could edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        end
+      end
+    end
+
+    Role.destroy_all(user: @division1_user)
+    @division1_user.destroy!
+  end
 end

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -53,4 +53,18 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"New" button should only be shown for users with roles' do
+    run_as_user(users(:test_admin)) do
+      get labor_requests_path
+      assert_select "[id='toolbar_new']"
+    end
+
+    no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
+    run_as_user(no_role_user) do
+      get labor_requests_path
+      assert_select "[id='toolbar_new']", 0
+    end
+    no_role_user.destroy!
+  end
 end

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -6,7 +6,6 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
     @dept1 = departments_with_records[0]
     @dept2 = departments_with_records[1]
 
-
     @dept1_user = User.create(cas_directory_id: 'dept1', name: 'Dept1 User')
     Role.create!(user: @dept1_user,
                  role_type: RoleType.find_by_code('department'),
@@ -76,7 +75,7 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
       patch labor_request_path(dept1_request), labor_request: { position_description: 'Foo' }
       assert_redirected_to labor_request_path(dept1_request)
 
-      patch labor_request_path(dept2_request),labor_request: { position_description: 'Foo' }
+      patch labor_request_path(dept2_request), labor_request: { position_description: 'Foo' }
       assert_response :forbidden
 
       # Destroy
@@ -87,5 +86,4 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :forbidden
     end
   end
-
 end

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -18,10 +18,17 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
   end
 
   def test_verify_authorization_in_controller
-    run_as_user(@dept1_user) do
-      dept1_request = LaborRequest.where(department: @dept1)[0]
-      dept2_request = LaborRequest.where(department: @dept2)[0]
+    no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
+    run_as_user(no_role_user) do
+      # New
+      get new_labor_request_path
+      assert_response :forbidden
+    end
+    no_role_user.destroy!
 
+    dept1_request = LaborRequest.where(department: @dept1)[0]
+    dept2_request = LaborRequest.where(department: @dept2)[0]
+    run_as_user(@dept1_user) do
       # Show
       get labor_request_path(dept1_request)
       assert_response :success
@@ -30,6 +37,8 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :forbidden
 
       # New
+      get new_labor_request_path
+      assert_response :success
 
       # Edit
       get edit_labor_request_path(dept1_request)

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -40,6 +40,37 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
       assert_response :forbidden
 
       # Create
+      post labor_requests_path, labor_request: {
+        contractor_name: dept1_request.contractor_name,
+        department_id: dept1_request.department_id,
+        employee_type_id: dept1_request.employee_type_id,
+        hourly_rate: dept1_request.hourly_rate,
+        hours_per_week: dept1_request.hours_per_week,
+        justification: dept1_request.justification,
+        nonop_funds: dept1_request.nonop_funds,
+        nonop_source: dept1_request.nonop_source,
+        number_of_positions: dept1_request.number_of_positions,
+        number_of_weeks: dept1_request.number_of_weeks,
+        position_description: dept1_request.position_description,
+        request_type_id: dept1_request.request_type_id,
+        unit_id: dept1_request.unit_id }
+      assert_redirected_to labor_request_path(assigns(:labor_request))
+
+      post labor_requests_path, labor_request: {
+        contractor_name: dept2_request.contractor_name,
+        department_id: dept2_request.department_id,
+        employee_type_id: dept2_request.employee_type_id,
+        hourly_rate: dept2_request.hourly_rate,
+        hours_per_week: dept2_request.hours_per_week,
+        justification: dept2_request.justification,
+        nonop_funds: dept2_request.nonop_funds,
+        nonop_source: dept2_request.nonop_source,
+        number_of_positions: dept2_request.number_of_positions,
+        number_of_weeks: dept2_request.number_of_weeks,
+        position_description: dept2_request.position_description,
+        request_type_id: dept2_request.request_type_id,
+        unit_id: dept2_request.unit_id }
+      assert_response :forbidden
 
       # Update
       patch labor_request_path(dept1_request), labor_request: { position_description: 'Foo' }

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -17,6 +17,7 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
     @dept1_user.destroy!
   end
 
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def test_verify_authorization_in_controller
     no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
     run_as_user(no_role_user) do

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -1,0 +1,60 @@
+require 'test_helper'
+
+# Integration test for Personnel Request Policy
+class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
+    @dept1 = departments_with_records[0]
+    @dept2 = departments_with_records[1]
+
+
+    @dept1_user = User.create(cas_directory_id: 'dept1', name: 'Dept1 User')
+    Role.create!(user: @dept1_user,
+                 role_type: RoleType.find_by_code('department'),
+                 department: @dept1)
+  end
+
+  def teardown
+    Role.destroy_all(user: @dept1_user)
+    @dept1_user.destroy!
+  end
+
+  def test_verify_authorization_in_controller
+    run_as_user(@dept1_user) do
+      dept1_request = LaborRequest.where(department: @dept1)[0]
+      dept2_request = LaborRequest.where(department: @dept2)[0]
+
+      # Show
+      get labor_request_path(dept1_request)
+      assert_response :success
+
+      get labor_request_path(dept2_request)
+      assert_response :forbidden
+
+      # New
+
+      # Edit
+      get edit_labor_request_path(dept1_request)
+      assert_response :success
+
+      get edit_labor_request_path(dept2_request)
+      assert_response :forbidden
+
+      # Create
+
+      # Update
+      patch labor_request_path(dept1_request), labor_request: { position_description: 'Foo' }
+      assert_redirected_to labor_request_path(dept1_request)
+
+      patch labor_request_path(dept2_request),labor_request: { position_description: 'Foo' }
+      assert_response :forbidden
+
+      # Destroy
+      delete labor_request_path(dept1_request)
+      assert_redirected_to labor_requests_url
+
+      delete labor_request_path(dept2_request)
+      assert_response :forbidden
+    end
+  end
+
+end

--- a/test/integration/staff_requests_edit_test.rb
+++ b/test/integration/staff_requests_edit_test.rb
@@ -17,4 +17,32 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"Edit" button should only be shown if policy allows edit' do
+    @division1 = divisions_with_records[0]
+    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
+    Role.create!(user: @division1_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: @division1)
+
+    run_as_user(@division1_user) do
+      staff_requests_all = StaffRequest.all
+
+      staff_requests_all.each do |r|
+        get staff_request_path(r)
+        if Pundit.policy!(@division1_user, r).edit?
+          assert_select "[id='button_edit']", 1,
+                        "'#{@division1.code}' user could NOT edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        else
+          assert_select "[id='button_edit']", 0,
+                        "'#{@division1.code}' user could edit " \
+                        "'#{r.id}' with division '#{r.department.division.code}'"
+        end
+      end
+    end
+
+    Role.destroy_all(user: @division1_user)
+    @division1_user.destroy!
+  end
 end

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -52,4 +52,18 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test '"New" button should only be shown for users with roles' do
+    run_as_user(users(:test_admin)) do
+      get staff_requests_path
+      assert_select "[id='toolbar_new']"
+    end
+
+    no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
+    run_as_user(no_role_user) do
+      get staff_requests_path
+      assert_select "[id='toolbar_new']", 0
+    end
+    no_role_user.destroy!
+  end
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -50,5 +50,4 @@ class UserTest < ActiveSupport::TestCase
     assert_equal 1, users(:test_admin).roles.count
     assert_equal role_types(:admin), users(:test_admin).roles[0].role_type
   end
-
 end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -26,4 +26,29 @@ class UserTest < ActiveSupport::TestCase
     @user.name = '  '
     assert_not @user.valid?
   end
+
+  test 'admin? should correct admin status of user' do
+    refute @user.admin?
+    assert users(:test_admin).admin?
+    refute users(:test_not_admin).admin?
+  end
+
+  test 'division? should correct division status of user' do
+    refute @user.division?
+    refute users(:test_admin).division?
+
+    division_user = User.new(cas_directory_id: 'division_user', name: 'Division User')
+    Role.create!(user: division_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: Division.all[0])
+    assert division_user.division?
+  end
+
+  test 'roles should return roles for the user' do
+    assert @user.roles.empty?
+
+    assert_equal 1, users(:test_admin).roles.count
+    assert_equal role_types(:admin), users(:test_admin).roles[0].role_type
+  end
+
 end

--- a/test/policies/personnel_request_policy_scope_test.rb
+++ b/test/policies/personnel_request_policy_scope_test.rb
@@ -42,7 +42,7 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
   end
 
   test 'department role can only see department personnel requests' do
-    expected_department_code = department_codes_with_records[0]
+    expected_department_code = departments_with_records[0].code
     Role.create!(user: @test_user,
                  role_type: RoleType.find_by_code('department'),
                  department: Department.find_by_code(expected_department_code))
@@ -62,7 +62,7 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
   end
 
   test 'unit role can only see unit personnel requests' do
-    expected_unit_code = unit_codes_with_records[0]
+    expected_unit_code = units_with_records[0].code
     Role.create!(user: @test_user,
                  role_type: RoleType.find_by_code('unit'),
                  unit: Unit.find_by_code(expected_unit_code))
@@ -82,8 +82,8 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
   end
 
   test 'multi-department user can only see personnel requests from those departments' do
-    expected_department_code1 = department_codes_with_records[0]
-    expected_department_code2 = department_codes_with_records[1]
+    expected_department_code1 = departments_with_records[0].code
+    expected_department_code2 = departments_with_records[1].code
     Role.create!(user: @test_user,
                  role_type: RoleType.find_by_code('department'),
                  department: Department.find_by_code(expected_department_code1))
@@ -104,8 +104,8 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
   end
 
   test 'mixed department and unit user can only see personnel requests from that department or unit' do
-    expected_department_code = department_codes_with_records[0]
-    expected_unit_code = unit_codes_with_records[0]
+    expected_department_code = departments_with_records[0].code
+    expected_unit_code = units_with_records[0].code
     Role.create!(user: @test_user,
                  role_type: RoleType.find_by_code('department'),
                  department: Department.find_by_code(expected_department_code))
@@ -132,16 +132,4 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
     Role.destroy_all(user: @test_user)
     @test_user.destroy!
   end
-
-  private
-
-    # Returns an array of department codes that have at least one record
-    def department_codes_with_records
-      LaborRequest.select(:department_id).distinct.collect { |r| r.department.code }
-    end
-
-    # Returns an array of unit codes that have at least one record
-    def unit_codes_with_records
-      LaborRequest.select(:unit_id).distinct.collect { |r| r.unit.code unless r.unit.nil? }.compact
-    end
 end

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -6,7 +6,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     @admin_user = users(:test_admin)
     @division1 = divisions_with_records[0]
     @division2 = divisions_with_records[1]
-    @dept_not_in_division_1 = departments_with_records.keep_if{ |d| d.division != @division1 }[0]
+    @dept_not_in_division_1 = departments_with_records.keep_if { |d| d.division != @division1 }[0]
     @dept1 = departments_with_records[0]
     @dept2 = departments_with_records[1]
     @unit1 = units_with_records[0]
@@ -48,18 +48,6 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     assert_equal 1, departments.count
     assert_equal @dept1, departments[0]
 
-#    # Single Unit user
-#    unit1 = units_with_records[0]
-#    unit1_user = User.create(cas_directory_id: 'unit', name: 'Unit User')
-#    Role.create!(user: unit1_user,
-#                 role_type: RoleType.find_by_code('unit'),
-#                 unit: unit1)
-#    departments = PersonnelRequestPolicy.allowed_departments(unit1_user)
-#    assert_equal 1, departments.count
-#    assert_equal unit1.department, departments[0]
-#    Role.destroy_all(user: unit1_user)
-#    unit1_user.destroy!
-
     # Multiple department user
     multi_dept_user = User.create(cas_directory_id: 'multi_dept', name: 'Multi Department')
     Role.create!(user: multi_dept_user,
@@ -71,7 +59,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     departments = PersonnelRequestPolicy.allowed_departments(multi_dept_user)
     assert_equal 2, departments.count
     departments.each do |department|
-      assert (@dept1 == department) || (@dept2 == department)
+      assert((@dept1 == department) || (@dept2 == department))
     end
     Role.destroy_all(user: multi_dept_user)
     multi_dept_user.destroy!
@@ -87,7 +75,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     departments = PersonnelRequestPolicy.allowed_departments(multi_div_dept_user)
     assert_equal (Department.where(division: @division1).count + 1), departments.count
     departments.each do |department|
-      assert (@division1 == department.division) || (@dept_not_in_division_1 == department)
+      assert((@division1 == department.division) || (@dept_not_in_division_1 == department))
     end
     Role.destroy_all(user: multi_div_dept_user)
     multi_div_dept_user.destroy!
@@ -107,7 +95,14 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     unit1_user.destroy!
   end
 
+  test 'admin user can "show" all personnel requests' do
+    labor_requests_all = LaborRequest.all
 
+    labor_requests_all.each do |r|
+      assert Pundit.policy!(@admin_user, r).show?,
+             "Admin user could not 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
 
   test 'division user can "show" all personnel requests' do
     labor_requests_all = LaborRequest.all
@@ -118,40 +113,49 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     end
   end
 
-  test 'department user can "show" personnel requests in department' do
-    labor_requests_dept1 = LaborRequest.where(department: @dept1)
+  test 'department user can only "show" personnel requests in department' do
+    labor_requests_all = LaborRequest.all
+    allowed_departments = PersonnelRequestPolicy.allowed_departments(@dept1_user)
 
-    labor_requests_dept1.each do |r|
-      assert Pundit.policy!(@dept1_user, r).show?,
-            "Department user could not 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    allow_count = 0
+    disallow_count = 0
+    labor_requests_all.each do |r|
+      if allowed_departments.include?(r.department)
+        assert Pundit.policy!(@dept1_user, r).show?,
+               "User (dept=#{@dept1.code}) could not 'show' Labor Request id: #{r.id}, dept: #{r.department.code}"
+        allow_count += 1
+      else
+        refute Pundit.policy!(@dept1_user, r).show?,
+               "User (dept=#{@dept1.code}) could 'show' Labor Request id: #{r.id}, dept: #{r.department.code}"
+        disallow_count += 1
+      end
     end
+
+    assert allow_count > 0, 'No allowed departments were tested!'
+    assert disallow_count > 0, 'No disallowed departments were tested!'
   end
 
-  test 'department user should not "show" personnel requests outside department' do
-    labor_requests_not_dept1 = LaborRequest.where(department: @dept2)
+  test 'unit user can "show" personnel requests in unit' do
+    labor_requests_all = LaborRequest.all
+    allowed_units = PersonnelRequestPolicy.allowed_units(@unit1_user)
 
-    labor_requests_not_dept1.each do |r|
-      refute Pundit.policy!(@dept1_user, r).show?,
-            "Department user could 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    allow_count = 0
+    disallow_count = 0
+    labor_requests_all.each do |r|
+      if allowed_units.include?(r.unit)
+        assert Pundit.policy!(@unit1_user, r).show?,
+               "User (unit=#{@unit1.code}) could not 'show' Labor Request id: #{r.id}, unit: #{r.unit.code}"
+        allow_count += 1
+      else
+        refute Pundit.policy!(@unit1_user, r).show?,
+               "User (unit=#{@unit1.code}) could 'show' Labor Request id: #{r.id}, unit: " +
+               (r.unit.nil? ? nil : r.unit.code).to_s
+        disallow_count += 1
+      end
     end
-  end
 
-  test 'unit user can "show" personnel requests in department' do
-    labor_requests_unit1 = LaborRequest.where(unit: @unit1)
-
-    labor_requests_unit1.each do |r|
-      assert Pundit.policy!(@unit1_user, r).show?,
-            "Unit user (unit=#{@unit1.code}) could not 'show' Labor Request id: #{r.id}, unit: #{r.unit.code}"
-    end
-  end
-
-  test 'unit user should not "show" personnel requests outside unit' do
-    labor_requests_not_unit1 = LaborRequest.where(department: @unit1.department).where(unit: nil)
-
-    labor_requests_not_unit1.each do |r|
-      refute Pundit.policy!(@unit1_user, r).show?,
-            "Unit user (unit=#{@unit1.code}) could 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
-    end
+    assert allow_count > 0, 'No allowed units were tested!'
+    assert disallow_count > 0, 'No disallowed units were tested!'
   end
 
   def teardown

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -175,6 +175,88 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     assert disallow_count > 0, 'No disallowed units were tested!'
   end
 
+  test 'admin user can "create" all personnel requests' do
+    labor_requests_all = LaborRequest.all
+
+    labor_requests_all.each do |r|
+      assert Pundit.policy!(@admin_user, r).create?,
+             "Admin user could not 'create' " \
+             "Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  test 'division user can only "create" personnel requests in division' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@division1_user, r).create?
+        allow_count += 1
+        assert_equal @division1, r.department.division,
+                     "User (div=#{@division1.code}) could 'create' " \
+                     "Labor Request #{r.id}, div: #{r.department.division.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @division1, r.department.division,
+                         "User (div=#{@division1.code}) could not 'create' " \
+                         "Labor Request #{r.id}, div: #{r.department.division.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed divisions were tested!'
+    assert disallow_count > 0, 'No disallowed divisions were tested!'
+  end
+
+  test 'department user can only "create" personnel requests in department' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@dept1_user, r).create?
+        allow_count += 1
+        assert_equal @dept1, r.department,
+                     "User (dept=#{@dept1.code}) could 'create' " \
+                     "Labor Request id: #{r.id}, dept: #{r.department.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @dept1, r.department,
+                         "User (dept=#{@dept1.code}) could not 'create' " \
+                         "Labor Request id: #{r.id}, dept: #{r.department.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed departments were tested!'
+    assert disallow_count > 0, 'No disallowed departments were tested!'
+  end
+
+  test 'unit user can only "create" personnel requests in unit' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@unit1_user, r).create?
+        allow_count += 1
+        assert_equal @unit1, r.unit,
+                     "User (unit=#{@unit1.code}) could 'create' " \
+                     "Labor Request id: #{r.id}, unit: #{r.unit.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @unit1, r.unit,
+                         "User (unit=#{@unit1.code}) could not 'create' " \
+                         "Labor Request id: #{r.id}, unit: #{r.unit.nil? ? nil : r.unit.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed units were tested!'
+    assert disallow_count > 0, 'No disallowed units were tested!'
+  end
+
   test 'admin user can "update" all personnel requests' do
     labor_requests_all = LaborRequest.all
 

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -1,7 +1,9 @@
 require 'test_helper'
 
 # Tests for PersonnelRequestPolicy class
+# rubocop:disable Metrics/ClassLength
 class PersonnelRequestPolicyTest < ActiveSupport::TestCase
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def setup
     @division1 = divisions_with_records[0]
     @division2 = divisions_with_records[1]

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -151,7 +151,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     assert disallow_count > 0, 'No disallowed departments were tested!'
   end
 
-  test 'unit user can "show" personnel requests in unit' do
+  test 'unit user can only "show" personnel requests in unit' do
     labor_requests_all = LaborRequest.all
 
     allow_count = 0
@@ -184,7 +184,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     end
   end
 
-  test 'division user can only "update" all personnel requests in division' do
+  test 'division user can only "update" personnel requests in division' do
     labor_requests_all = LaborRequest.all
 
     allow_count = 0
@@ -232,7 +232,7 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     assert disallow_count > 0, 'No disallowed departments were tested!'
   end
 
-  test 'unit user can "update" personnel requests in unit' do
+  test 'unit user can only "update" personnel requests in unit' do
     labor_requests_all = LaborRequest.all
 
     allow_count = 0
@@ -247,6 +247,86 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
         disallow_count += 1
         assert_not_equal @unit1, r.unit,
                          "User (unit=#{@unit1.code}) could not 'update' " \
+                         "Labor Request id: #{r.id}, unit: #{r.unit.nil? ? nil : r.unit.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed units were tested!'
+    assert disallow_count > 0, 'No disallowed units were tested!'
+  end
+
+  test 'admin user can "destroy" all personnel requests' do
+    labor_requests_all = LaborRequest.all
+
+    labor_requests_all.each do |r|
+      assert Pundit.policy!(@admin_user, r).destroy?,
+             "Admin user could not 'destroy' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  test 'division user can only "destroy" personnel requests in division' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@division1_user, r).destroy?
+        allow_count += 1
+        assert_equal @division1, r.department.division,
+                     "User (div=#{@division1.code}) could 'destroy' " \
+                     "Labor Request #{r.id}, div: #{r.department.division.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @division1, r.department.division,
+                         "User (div=#{@division1.code}) could not 'destroy' " \
+                         "Labor Request #{r.id}, div: #{r.department.division.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed divisions were tested!'
+    assert disallow_count > 0, 'No disallowed divisions were tested!'
+  end
+
+  test 'department user can only "destroy" personnel requests in department' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@dept1_user, r).destroy?
+        allow_count += 1
+        assert_equal @dept1, r.department,
+                     "User (dept=#{@dept1.code}) could 'destroy' " \
+                     "Labor Request id: #{r.id}, dept: #{r.department.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @dept1, r.department,
+                         "User (dept=#{@dept1.code}) could not 'destroy' " \
+                         "Labor Request id: #{r.id}, dept: #{r.department.code}"
+      end
+    end
+
+    assert allow_count > 0, 'No allowed departments were tested!'
+    assert disallow_count > 0, 'No disallowed departments were tested!'
+  end
+
+  test 'unit user can only "destroy" personnel requests in unit' do
+    labor_requests_all = LaborRequest.all
+
+    allow_count = 0
+    disallow_count = 0
+    labor_requests_all.each do |r|
+      if Pundit.policy!(@unit1_user, r).destroy?
+        allow_count += 1
+        assert_equal @unit1, r.unit,
+                     "User (unit=#{@unit1.code}) could 'destroy' " \
+                     "Labor Request id: #{r.id}, unit: #{r.unit.code}"
+      else
+        disallow_count += 1
+        assert_not_equal @unit1, r.unit,
+                         "User (unit=#{@unit1.code}) could not 'destroy' " \
                          "Labor Request id: #{r.id}, unit: #{r.unit.nil? ? nil : r.unit.code}"
       end
     end

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -416,4 +416,14 @@ class PersonnelRequestPolicyTest < ActiveSupport::TestCase
     assert allow_count > 0, 'No allowed units were tested!'
     assert disallow_count > 0, 'No disallowed units were tested!'
   end
+
+  test 'user with any roles should be able to "new" personnel requests' do
+    assert Pundit.policy!(@dept1_user, LaborRequest).new?
+  end
+
+  test 'user without roles should not be able to "new" personnel requests' do
+    @no_role_user = User.create(cas_directory_id: 'no_role', name: 'No Role')
+    refute Pundit.policy!(@no_role_user, LaborRequest).new?
+    @no_role_user.destroy!
+  end
 end

--- a/test/policies/personnel_request_policy_test.rb
+++ b/test/policies/personnel_request_policy_test.rb
@@ -1,0 +1,167 @@
+require 'test_helper'
+
+# Tests for PersonnelRequestPolicy class
+class PersonnelRequestPolicyTest < ActiveSupport::TestCase
+  def setup
+    @admin_user = users(:test_admin)
+    @division1 = divisions_with_records[0]
+    @division2 = divisions_with_records[1]
+    @dept_not_in_division_1 = departments_with_records.keep_if{ |d| d.division != @division1 }[0]
+    @dept1 = departments_with_records[0]
+    @dept2 = departments_with_records[1]
+    @unit1 = units_with_records[0]
+
+    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
+    Role.create!(user: @division1_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: @division1)
+
+    @dept1_user = User.create(cas_directory_id: 'dept1', name: 'Dept1 User')
+    Role.create!(user: @dept1_user,
+                 role_type: RoleType.find_by_code('department'),
+                 department: @dept1)
+
+    @unit1_user = User.create(cas_directory_id: 'unit1', name: 'Unit1 User')
+    Role.create!(user: @unit1_user,
+                 role_type: RoleType.find_by_code('unit'),
+                 unit: @unit1)
+  end
+
+  test 'verify departments_in_division returns correct departments' do
+    departments = PersonnelRequestPolicy.departments_in_division(@division1)
+    assert departments.count > 0
+    departments.each do |d|
+      assert d.division == @division1
+    end
+  end
+
+  test 'verify allowed_departments returns correct departments' do
+    # Division user
+    departments = PersonnelRequestPolicy.allowed_departments(@division1_user)
+    assert_equal Department.where(division: @division1).count, departments.count
+    departments.each do |department|
+      assert_equal @division1, department.division
+    end
+
+    # Single department user
+    departments = PersonnelRequestPolicy.allowed_departments(@dept1_user)
+    assert_equal 1, departments.count
+    assert_equal @dept1, departments[0]
+
+#    # Single Unit user
+#    unit1 = units_with_records[0]
+#    unit1_user = User.create(cas_directory_id: 'unit', name: 'Unit User')
+#    Role.create!(user: unit1_user,
+#                 role_type: RoleType.find_by_code('unit'),
+#                 unit: unit1)
+#    departments = PersonnelRequestPolicy.allowed_departments(unit1_user)
+#    assert_equal 1, departments.count
+#    assert_equal unit1.department, departments[0]
+#    Role.destroy_all(user: unit1_user)
+#    unit1_user.destroy!
+
+    # Multiple department user
+    multi_dept_user = User.create(cas_directory_id: 'multi_dept', name: 'Multi Department')
+    Role.create!(user: multi_dept_user,
+                 role_type: RoleType.find_by_code('department'),
+                 department: @dept1)
+    Role.create!(user: multi_dept_user,
+                 role_type: RoleType.find_by_code('department'),
+                 department: @dept2)
+    departments = PersonnelRequestPolicy.allowed_departments(multi_dept_user)
+    assert_equal 2, departments.count
+    departments.each do |department|
+      assert (@dept1 == department) || (@dept2 == department)
+    end
+    Role.destroy_all(user: multi_dept_user)
+    multi_dept_user.destroy!
+
+    # Division and department user
+    multi_div_dept_user = User.create(cas_directory_id: 'multi_div_dept', name: 'Multi Div-Department')
+    Role.create!(user: multi_div_dept_user,
+                 role_type: RoleType.find_by_code('division'),
+                 division: @division1)
+    Role.create!(user: multi_div_dept_user,
+                 role_type: RoleType.find_by_code('department'),
+                 department: @dept_not_in_division_1)
+    departments = PersonnelRequestPolicy.allowed_departments(multi_div_dept_user)
+    assert_equal (Department.where(division: @division1).count + 1), departments.count
+    departments.each do |department|
+      assert (@division1 == department.division) || (@dept_not_in_division_1 == department)
+    end
+    Role.destroy_all(user: multi_div_dept_user)
+    multi_div_dept_user.destroy!
+  end
+
+  test 'verify allowed_units returns correct units' do
+    # Single Unit user
+    unit1 = units_with_records[0]
+    unit1_user = User.create(cas_directory_id: 'unit', name: 'Unit User')
+    Role.create!(user: unit1_user,
+                 role_type: RoleType.find_by_code('unit'),
+                 unit: unit1)
+    units = PersonnelRequestPolicy.allowed_units(unit1_user)
+    assert_equal 1, units.count
+    assert_equal unit1, units[0]
+    Role.destroy_all(user: unit1_user)
+    unit1_user.destroy!
+  end
+
+
+
+  test 'division user can "show" all personnel requests' do
+    labor_requests_all = LaborRequest.all
+
+    labor_requests_all.each do |r|
+      assert Pundit.policy!(@division1_user, r).show?,
+             "Division user could not 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  test 'department user can "show" personnel requests in department' do
+    labor_requests_dept1 = LaborRequest.where(department: @dept1)
+
+    labor_requests_dept1.each do |r|
+      assert Pundit.policy!(@dept1_user, r).show?,
+            "Department user could not 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  test 'department user should not "show" personnel requests outside department' do
+    labor_requests_not_dept1 = LaborRequest.where(department: @dept2)
+
+    labor_requests_not_dept1.each do |r|
+      refute Pundit.policy!(@dept1_user, r).show?,
+            "Department user could 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  test 'unit user can "show" personnel requests in department' do
+    labor_requests_unit1 = LaborRequest.where(unit: @unit1)
+
+    labor_requests_unit1.each do |r|
+      assert Pundit.policy!(@unit1_user, r).show?,
+            "Unit user (unit=#{@unit1.code}) could not 'show' Labor Request id: #{r.id}, unit: #{r.unit.code}"
+    end
+  end
+
+  test 'unit user should not "show" personnel requests outside unit' do
+    labor_requests_not_unit1 = LaborRequest.where(department: @unit1.department).where(unit: nil)
+
+    labor_requests_not_unit1.each do |r|
+      refute Pundit.policy!(@unit1_user, r).show?,
+            "Unit user (unit=#{@unit1.code}) could 'show' Labor Request id: #{r.id}, department: #{r.department.code}"
+    end
+  end
+
+  def teardown
+    Role.destroy_all(user: @division1_user)
+    @division1_user.destroy!
+
+    Role.destroy_all(user: @dept1_user)
+    @dept1_user.destroy!
+
+    Role.destroy_all(user: @unit1_user)
+    @unit1_user.destroy!
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,4 +32,19 @@ class ActiveSupport::TestCase
       CASClient::Frameworks::Rails::Filter.fake(ActiveSupport::TestCase::DEFAULT_TEST_USER)
     end
   end
+
+    # Returns an array of divisions that have at least one record
+    def divisions_with_records
+      LaborRequest.select(:department_id).distinct.collect { |r| r.department.division }.uniq
+    end
+
+    # Returns an array of departments that have at least one record
+    def departments_with_records
+      LaborRequest.select(:department_id).distinct.collect { |r| r.department }
+    end
+
+    # Returns an array of units that have at least one record
+    def units_with_records
+      LaborRequest.select(:unit_id).distinct.collect { |r| r.unit unless r.unit.nil? }.compact
+    end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,18 +33,18 @@ class ActiveSupport::TestCase
     end
   end
 
-    # Returns an array of divisions that have at least one record
-    def divisions_with_records
-      LaborRequest.select(:department_id).distinct.collect { |r| r.department.division }.uniq
-    end
+  # Returns an array of divisions that have at least one record
+  def divisions_with_records
+    LaborRequest.select(:department_id).distinct.collect { |r| r.department.division }.uniq
+  end
 
-    # Returns an array of departments that have at least one record
-    def departments_with_records
-      LaborRequest.select(:department_id).distinct.collect { |r| r.department }
-    end
+  # Returns an array of departments that have at least one record
+  def departments_with_records
+    LaborRequest.select(:department_id).distinct.collect(&:department)
+  end
 
-    # Returns an array of units that have at least one record
-    def units_with_records
-      LaborRequest.select(:unit_id).distinct.collect { |r| r.unit unless r.unit.nil? }.compact
-    end
+  # Returns an array of units that have at least one record
+  def units_with_records
+    LaborRequest.select(:unit_id).distinct.collect { |r| r.unit unless r.unit.nil? }.compact
+  end
 end


### PR DESCRIPTION
Limited create, read, update, and delete functions for personnel requests, based on user roles using Pundit.

Modifications were made to both controller actions (so that even direct URL requests would be sent to a "Not Authorized" page, if the user did not have the appropriate permissions, and to the suppression of GUI elements, such as the "New" or "Edit" button, that would lead to a "Not Authorized" page.

Policy is defined in the app/policies/personnel_request_policy.rb file.

https://issues.umd.edu/browse/LIBITD-439