### PR TITLE
LIBITD-498. Implement improved umd_lib_style from mockup

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 
 GIT
   remote: git://github.com/umd-lib/umd_lib_style.git
-  revision: 4a78329d6a1cd33256263fcdfccc02cc35d70d20
+  revision: 82421bcb6a7a223cb5d39668cf3417cbc6dd2533
   branch: develop
   specs:
     umd_lib_style (0.1.0)

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -13,7 +13,7 @@
  *= require_tree .
  *= require_self
  */
-$grid-float-breakpoint: 1000px;
+ 
 @import "umd_lib";
 
 // Default links to black text, instead of red


### PR DESCRIPTION
Removed the grid-float-breakpoint setting.

The grid-float-breakpoint in umd_lib_style has a sensible default
(1200px) for this application, so there is no need to set it in both
places.

If the default grid-float-breakpoint setting ever becomes unsuitable,
it can be overridden by adding the setting to this file.

https://issues.umd.edu/browse/LIBITD-498