### PR TITLE
LIBITD-441. Limit "Department" and "Unit" based on role permissions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ test/reports
 .env
 .env.production
 
+# Ignore byebug history
+.byebug_history

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -23,16 +23,18 @@ class ContractorRequestsController < ApplicationController
   def new
     authorize ContractorRequest
     @contractor_request = ContractorRequest.new
+    assign_selectable_departments_and_units(@contractor_request)
   end
 
   # GET /contractor_requests/1/edit
   def edit
     authorize @contractor_request
+    assign_selectable_departments_and_units(@contractor_request)
   end
 
   # POST /contractor_requests
   # POST /contractor_requests.json
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength,  Metrics/AbcSize
   def create
     @contractor_request = ContractorRequest.new(contractor_request_params)
     authorize @contractor_request
@@ -42,14 +44,19 @@ class ContractorRequestsController < ApplicationController
         format.html { redirect_to @contractor_request, notice: 'Contractor request was successfully created.' }
         format.json { render :show, status: :created, location: @contractor_request }
       else
-        format.html { render :new }
+        format.html do
+          assign_selectable_departments_and_units(@contractor_request)
+          render :new
+        end
         format.json { render json: @contractor_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength,  Metrics/AbcSize
 
   # PATCH/PUT /contractor_requests/1
   # PATCH/PUT /contractor_requests/1.json
+  # rubocop:disable Metrics/MethodLength
   def update
     authorize @contractor_request
     respond_to do |format|
@@ -57,11 +64,15 @@ class ContractorRequestsController < ApplicationController
         format.html { redirect_to @contractor_request, notice: 'Contractor request was successfully updated.' }
         format.json { render :show, status: :ok, location: @contractor_request }
       else
-        format.html { render :edit }
+        format.html do
+          assign_selectable_departments_and_units(@contractor_request)
+          render :edit
+        end
         format.json { render json: @contractor_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # DELETE /contractor_requests/1
   # DELETE /contractor_requests/1.json

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -23,16 +23,18 @@ class LaborRequestsController < ApplicationController
   def new
     authorize LaborRequest
     @labor_request = LaborRequest.new
+    assign_selectable_departments_and_units(@labor_request)
   end
 
   # GET /labor_requests/1/edit
   def edit
     authorize @labor_request
+    assign_selectable_departments_and_units(@labor_request)
   end
 
   # POST /labor_requests
   # POST /labor_requests.json
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def create
     @labor_request = LaborRequest.new(labor_request_params)
     authorize @labor_request
@@ -42,14 +44,19 @@ class LaborRequestsController < ApplicationController
         format.html { redirect_to @labor_request, notice: 'Labor request was successfully created.' }
         format.json { render :show, status: :created, location: @labor_request }
       else
-        format.html { render :new }
+        format.html do
+          assign_selectable_departments_and_units(@labor_request)
+          render :new
+        end
         format.json { render json: @labor_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # PATCH/PUT /labor_requests/1
   # PATCH/PUT /labor_requests/1.json
+  # rubocop:disable Metrics/MethodLength
   def update
     authorize @labor_request
     respond_to do |format|
@@ -57,11 +64,15 @@ class LaborRequestsController < ApplicationController
         format.html { redirect_to @labor_request, notice: 'Labor request was successfully updated.' }
         format.json { render :show, status: :ok, location: @labor_request }
       else
-        format.html { render :edit }
+        format.html do
+          assign_selectable_departments_and_units(@labor_request)
+          render :edit
+        end
         format.json { render json: @labor_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # DELETE /labor_requests/1
   # DELETE /labor_requests/1.json

--- a/app/controllers/personnel_request_controller.rb
+++ b/app/controllers/personnel_request_controller.rb
@@ -3,4 +3,12 @@
 # and open the template in the editor.
 
 module PersonnelRequestController
+  # Sets the @selectable_units and @selectable_department variables for the
+  # given personnel request and current user.
+  #
+  # personnel_request: The personnel request shown in the GUI.
+  def assign_selectable_departments_and_units(personnel_request)
+    @selectable_units = policy(personnel_request).selectable_units(@current_user).sort_by(&:name)
+    @selectable_departments = policy(personnel_request).selectable_departments(@current_user).sort_by(&:name)
+  end
 end

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -23,16 +23,18 @@ class StaffRequestsController < ApplicationController
   def new
     authorize StaffRequest
     @staff_request = StaffRequest.new
+    assign_selectable_departments_and_units(@staff_request)
   end
 
   # GET /staff_requests/1/edit
   def edit
     authorize @staff_request
+    assign_selectable_departments_and_units(@staff_request)
   end
 
   # POST /staff_requests
   # POST /staff_requests.json
-  # rubocop:disable Metrics/MethodLength
+  # rubocop:disable Metrics/MethodLength, Metrics/AbcSize
   def create
     @staff_request = StaffRequest.new(staff_request_params)
     authorize @staff_request
@@ -42,14 +44,19 @@ class StaffRequestsController < ApplicationController
         format.html { redirect_to @staff_request, notice: 'Staff request was successfully created.' }
         format.json { render :show, status: :created, location: @staff_request }
       else
-        format.html { render :new }
+        format.html do
+          assign_selectable_departments_and_units(@staff_request)
+          render :new
+        end
         format.json { render json: @staff_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength, Metrics/AbcSize
 
   # PATCH/PUT /staff_requests/1
   # PATCH/PUT /staff_requests/1.json
+  # rubocop:disable Metrics/MethodLength
   def update
     authorize @staff_request
     respond_to do |format|
@@ -57,11 +64,15 @@ class StaffRequestsController < ApplicationController
         format.html { redirect_to @staff_request, notice: 'Staff request was successfully updated.' }
         format.json { render :show, status: :ok, location: @staff_request }
       else
-        format.html { render :edit }
+        format.html do
+          assign_selectable_departments_and_units(@staff_request)
+          render :new
+        end
         format.json { render json: @staff_request.errors, status: :unprocessable_entity }
       end
     end
   end
+  # rubocop:enable Metrics/MethodLength
 
   # DELETE /staff_requests/1
   # DELETE /staff_requests/1.json

--- a/app/views/contractor_requests/_form.html.erb
+++ b/app/views/contractor_requests/_form.html.erb
@@ -41,13 +41,18 @@
       </tr>
       <tr>
         <th><%= f.label :department_id %></th>
-        <td><%= select("contractor_request", "department_id", Department.order("name").collect { |d| [ d.name, d.id ] }, { prompt: 'Select Department' }) %></td>
+        <td>
+          <%=
+            depts = @selectable_departments.collect { |d| [ d.name, d.id ] }
+            select("contractor_request", "department_id", depts, { prompt: 'Select Department' })
+          %>
+        </td>
       </tr>
       <tr>
         <th><%= f.label :unit_id %></th>
         <td>
           <%= 
-            units = Unit.order("name").collect { |d| [ d.name, d.id ] }
+            units = @selectable_units.collect { |u| [ u.name, u.id ] }
             # Prepend "<Clear Unit>" if unit is selected
             units.unshift( ["<Clear Unit>", nil ] ) if @contractor_request.unit
             select("contractor_request", "unit_id", units, { prompt: 'Select Unit' })

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -49,13 +49,18 @@
       </tr>
       <tr>
         <th><%= f.label :department_id %></th>
-        <td><%= select("labor_request", "department_id", Department.order("name").collect { |d| [ d.name, d.id ] }, { prompt: 'Select Department' }) %></td>
+        <td>
+          <%= 
+            depts = @selectable_departments.collect { |d| [ d.name, d.id ] }
+            select("labor_request", "department_id", depts, { prompt: 'Select Department' }) 
+          %>
+        </td>
       </tr>
       <tr>
         <th><%= f.label :unit_id %></th>
         <td>
           <%= 
-            units = Unit.order("name").collect { |d| [ d.name, d.id ] }
+            units = @selectable_units.collect { |u| [ u.name, u.id ] }
             # Prepend "<Clear Unit>" if unit is selected
             units.unshift( ["<Clear Unit>", nil ] ) if @labor_request.unit
             select("labor_request", "unit_id", units, { prompt: 'Select Unit' })

--- a/app/views/staff_requests/_form.html.erb
+++ b/app/views/staff_requests/_form.html.erb
@@ -33,13 +33,18 @@
       </tr>
       <tr>
         <th><%= f.label :department_id %></th>
-        <td><%= select("staff_request", "department_id", Department.order("name").collect { |d| [ d.name, d.id ] }, { prompt: 'Select Department' }) %></td>
+        <td>
+          <%=
+            depts = @selectable_departments.collect { |d| [ d.name, d.id ] }
+            select("staff_request", "department_id", depts, { prompt: 'Select Department' })
+          %>
+        </td>
       </tr>
       <tr>
         <th><%= f.label :unit_id %></th>
         <td>
           <%= 
-            units = Unit.order("name").collect { |d| [ d.name, d.id ] }
+            units = @selectable_units.collect { |u| [ u.name, u.id ] }
             # Prepend "<Clear Unit>" if unit is selected
             units.unshift( ["<Clear Unit>", nil ] ) if @staff_request.unit
             select("staff_request", "unit_id", units, { prompt: 'Select Unit' })

--- a/test/controllers/contractor_requests_controller_test.rb
+++ b/test/controllers/contractor_requests_controller_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class ContractorRequestsControllerTest < ActionController::TestCase
   setup do
     @contractor_request = contractor_requests(:c2)
@@ -33,6 +34,23 @@ class ContractorRequestsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to contractor_request_path(assigns(:contractor_request))
+  end
+
+  test 'should not create invalid contractor_request' do
+    assert_no_difference('ContractorRequest.count') do
+      post :create, contractor_request: {
+        annual_base_pay: nil,
+        contractor_name: nil,
+        department_id: nil,
+        employee_type_id: nil,
+        justification: nil,
+        nonop_funds: nil,
+        nonop_source: nil,
+        number_of_months: nil,
+        position_description: nil,
+        request_type_id: nil,
+        unit_id: nil }
+    end
   end
 
   test 'should show contractor_request' do
@@ -92,6 +110,21 @@ class ContractorRequestsControllerTest < ActionController::TestCase
       request_type_id: @contractor_request.request_type_id,
       unit_id: @contractor_request.unit_id }
     assert_redirected_to contractor_request_path(assigns(:contractor_request))
+  end
+
+  test 'should not update invalid contractor_request' do
+    patch :update, id: @contractor_request, contractor_request: {
+      annual_base_pay: nil,
+      contractor_name: nil,
+      department_id: nil,
+      employee_type_id: nil,
+      justification: nil,
+      nonop_funds: nil,
+      nonop_source: nil,
+      number_of_months: nil,
+      position_description: nil,
+      request_type_id: nil,
+      unit_id: nil }
   end
 
   test 'should destroy contractor_request' do

--- a/test/controllers/contractor_requests_controller_test.rb
+++ b/test/controllers/contractor_requests_controller_test.rb
@@ -113,6 +113,7 @@ class ContractorRequestsControllerTest < ActionController::TestCase
   end
 
   test 'should not update invalid contractor_request' do
+    original_attrs = @contractor_request.attributes
     patch :update, id: @contractor_request, contractor_request: {
       annual_base_pay: nil,
       contractor_name: nil,
@@ -125,6 +126,7 @@ class ContractorRequestsControllerTest < ActionController::TestCase
       position_description: nil,
       request_type_id: nil,
       unit_id: nil }
+    assert_equal original_attrs, ContractorRequest.find(@contractor_request.id).attributes
   end
 
   test 'should destroy contractor_request' do

--- a/test/controllers/labor_requests_controller_test.rb
+++ b/test/controllers/labor_requests_controller_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class LaborRequestsControllerTest < ActionController::TestCase
   setup do
     @labor_request = labor_requests(:c1)
@@ -35,6 +36,25 @@ class LaborRequestsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to labor_request_path(assigns(:labor_request))
+  end
+
+  test 'should not create invalid labor_request' do
+    assert_no_difference('LaborRequest.count') do
+      post :create, labor_request: {
+        contractor_name: nil,
+        department_id: nil,
+        employee_type_id: nil,
+        hourly_rate: nil,
+        hours_per_week: nil,
+        justification: nil,
+        nonop_funds: nil,
+        nonop_source: nil,
+        number_of_positions: nil,
+        number_of_weeks: nil,
+        position_description: nil,
+        request_type_id: nil,
+        unit_id: nil }
+    end
   end
 
   test 'should create/update labor_request but without admin only values when not admin' do
@@ -100,6 +120,25 @@ class LaborRequestsControllerTest < ActionController::TestCase
       review_comment: @labor_request.review_comment,
       unit_id: @labor_request.unit_id }
     assert_redirected_to labor_request_path(assigns(:labor_request))
+  end
+
+  test 'should not update invalid labor_request' do
+    assert_no_difference('LaborRequest.count') do
+      post :update, id: @labor_request, labor_request: {
+        contractor_name: nil,
+        department_id: nil,
+        employee_type_id: nil,
+        hourly_rate: nil,
+        hours_per_week: nil,
+        justification: nil,
+        nonop_funds: nil,
+        nonop_source: nil,
+        number_of_positions: nil,
+        number_of_weeks: nil,
+        position_description: nil,
+        request_type_id: nil,
+        unit_id: nil }
+    end
   end
 
   test 'should destroy labor_request' do

--- a/test/controllers/labor_requests_controller_test.rb
+++ b/test/controllers/labor_requests_controller_test.rb
@@ -123,22 +123,22 @@ class LaborRequestsControllerTest < ActionController::TestCase
   end
 
   test 'should not update invalid labor_request' do
-    assert_no_difference('LaborRequest.count') do
-      post :update, id: @labor_request, labor_request: {
-        contractor_name: nil,
-        department_id: nil,
-        employee_type_id: nil,
-        hourly_rate: nil,
-        hours_per_week: nil,
-        justification: nil,
-        nonop_funds: nil,
-        nonop_source: nil,
-        number_of_positions: nil,
-        number_of_weeks: nil,
-        position_description: nil,
-        request_type_id: nil,
-        unit_id: nil }
-    end
+    original_attrs = @labor_request.attributes
+    patch :update, id: @labor_request, labor_request: {
+      contractor_name: nil,
+      department_id: nil,
+      employee_type_id: nil,
+      hourly_rate: nil,
+      hours_per_week: nil,
+      justification: nil,
+      nonop_funds: nil,
+      nonop_source: nil,
+      number_of_positions: nil,
+      number_of_weeks: nil,
+      position_description: nil,
+      request_type_id: nil,
+      unit_id: nil }
+    assert_equal original_attrs, LaborRequest.find(@labor_request.id).attributes
   end
 
   test 'should destroy labor_request' do

--- a/test/controllers/staff_requests_controller_test.rb
+++ b/test/controllers/staff_requests_controller_test.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
 
+# rubocop:disable Metrics/ClassLength
 class StaffRequestsControllerTest < ActionController::TestCase
   setup do
     @staff_request = staff_requests(:fac)
@@ -46,6 +47,21 @@ class StaffRequestsControllerTest < ActionController::TestCase
     end
 
     assert_redirected_to staff_request_path(assigns(:staff_request))
+  end
+
+  test 'should not create invalid staff_request' do
+    assert_no_difference('StaffRequest.count') do
+      post :create, staff_request: {
+        annual_base_pay: nil,
+        department_id: nil,
+        employee_type_id: nil,
+        justification: nil,
+        nonop_funds: nil,
+        nonop_source: nil,
+        position_description: nil,
+        request_type_id: nil,
+        unit_id: nil }
+    end
   end
 
   test 'should show staff_request' do
@@ -101,6 +117,21 @@ class StaffRequestsControllerTest < ActionController::TestCase
       request_type_id: @staff_request.request_type_id,
       unit_id: @staff_request.unit_id }
     assert_redirected_to staff_request_path(assigns(:staff_request))
+  end
+
+  test 'should not update invalid staff_request' do
+    original_attrs = @staff_request.attributes
+    patch :update, id: @staff_request, staff_request: {
+      annual_base_pay: nil,
+      department_id: nil,
+      employee_type_id: nil,
+      justification: nil,
+      nonop_funds: nil,
+      nonop_source: nil,
+      position_description: nil,
+      request_type_id: nil,
+      unit_id: nil }
+    assert_equal original_attrs, StaffRequest.find(@staff_request.id).attributes
   end
 
   test 'should destroy staff_request' do

--- a/test/fixtures/contractor_requests.yml
+++ b/test/fixtures/contractor_requests.yml
@@ -29,6 +29,19 @@ cont_fac_renewal:
   unit: nil
   justification: They used mind control on me
 
+c2_with_unit:
+  employee_type: c2
+  position_description: Medieval Studies Librarian
+  request_type: new
+  contractor_name: nil
+  number_of_months: 3
+  annual_base_pay: 10_000.00
+  nonop_funds: nil
+  nonop_source: nil
+  department: rl
+  unit: arch
+  justification: Specialization is medieval plumbing technologies.
+
 # Sample data for pagination
 contractor_request_1:
   employee_type: cont_fac

--- a/test/fixtures/labor_requests.yml
+++ b/test/fixtures/labor_requests.yml
@@ -32,6 +32,22 @@ fac_hrly_renewal:
   unit: nil
   justification: Can't have enough expertise for this topic.
 
+fac_hrly_with_unit:
+  employee_type: fac_hrly
+  position_description: Shelving Roboticist
+  request_type: renewal
+  contractor_name: Susan Calvin
+  number_of_positions: 1
+  hourly_rate: 100.00
+  hours_per_week: 40.00
+  number_of_weeks: 30
+  nonop_funds: nil
+  nonop_source: nil
+  department: as
+  unit: stk
+  justification: Has expertise in the Three Laws of Robotics
+  
+
 # Sample data for pagination
 labor_request_1:
   employee_type: student

--- a/test/fixtures/staff_requests.yml
+++ b/test/fixtures/staff_requests.yml
@@ -8,7 +8,7 @@ fac:
   nonop_funds: 0.00
   nonop_source: nil
   department: prg
-  unit_id: nil
+  unit: nil
   justification: Because we really really need someone.
 
 staff_request_with_status:
@@ -19,10 +19,21 @@ staff_request_with_status:
   nonop_funds: 0.00
   nonop_source: nil
   department: ssdr
-  unit_id: nil
+  unit: nil
   justification: Because we really really need a big tuna.
   review_status: started
   review_comment: This guy is kind of a big deal.
+  
+fac_with_unit:
+  employee_type: fac
+  position_description: Architecture Faculty Position
+  request_type: new
+  annual_base_pay: 50000.00
+  nonop_funds: 0.00
+  nonop_source: nil
+  department: rl
+  unit: arch
+  justification: Because.
 
 # Sample data for pagination
 staff_request_1:

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -8,10 +8,6 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
   def setup
     @contractor_request = contractor_requests(:cont_fac_renewal)
     @division1 = divisions_with_records[0]
-    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
-    Role.create!(user: @division1_user,
-                 role_type: RoleType.find_by_code('division'),
-                 division: @division1)
   end
 
   test 'currency field values show with two decimal places' do
@@ -26,25 +22,24 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test '"Edit" button should only be shown if policy allows edit' do
-    run_as_user(@division1_user) do
-      contractor_requests_all = ContractorRequest.all
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        contractor_requests_all = ContractorRequest.all
 
-      contractor_requests_all.each do |r|
-        get contractor_request_path(r)
-        if Pundit.policy!(@division1_user, r).edit?
-          assert_select "[id='button_edit']", 1,
-                        "'#{@division1.code}' user could NOT edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
-        else
-          assert_select "[id='button_edit']", 0,
-                        "'#{@division1.code}' user could edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
+        contractor_requests_all.each do |r|
+          get contractor_request_path(r)
+          if Pundit.policy!(temp_user, r).edit?
+            assert_select "[id='button_edit']", 1,
+                          "'#{@division1.code}' user could NOT edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          else
+            assert_select "[id='button_edit']", 0,
+                          "'#{@division1.code}' user could edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          end
         end
       end
     end
-
-    Role.destroy_all(user: @division1_user)
-    @division1_user.destroy!
   end
 
   test 'can edit review_status or review_comments' do
@@ -54,10 +49,12 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test 'Non-admins cannot edit review_status or review_comments' do
-    run_as_user(@division1_user) do
-      get edit_contractor_request_path(@contractor_request)
-      assert_select "select#contractor_request_review_status_id[disabled='disabled']"
-      assert_select "textarea#contractor_request_review_comment[disabled='disabled']"
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        get edit_contractor_request_path(@contractor_request)
+        assert_select "select#contractor_request_review_status_id[disabled='disabled']"
+        assert_select "textarea#contractor_request_review_comment[disabled='disabled']"
+      end
     end
   end
 

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the ContractorRequest edit page
 class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
+  include PersonnelRequestsTestHelper
+
   def setup
     @contractor_request = contractor_requests(:cont_fac_renewal)
     @division1 = divisions_with_records[0]
@@ -55,6 +58,60 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
       get edit_contractor_request_path(@contractor_request)
       assert_select "select#contractor_request_review_status_id[disabled='disabled']"
       assert_select "textarea#contractor_request_review_comment[disabled='disabled']"
+    end
+  end
+
+  test 'can only see departments/units allowed by role in drop-downs' do
+    contractor_request_with_unit = contractor_requests(:c2_with_unit)
+    with_temp_user(units: [contractor_request_with_unit.unit.code]) do |temp_user|
+      run_as_user(temp_user) do
+        get edit_contractor_request_path(contractor_request_with_unit)
+
+        # Verify department options
+        expected_options = [contractor_request_with_unit.unit.department.name]
+        verify_options(response, 'contractor_request_department_id', expected_options)
+
+        # Verify unit options
+        expected_options = ['<Clear Unit>', contractor_request_with_unit.unit.name]
+        verify_options(response, 'contractor_request_unit_id', expected_options)
+      end
+    end
+  end
+
+  test 'can only see departments/units allowed by role in drop-downs with role cutoffs' do
+    contractor_request = contractor_requests(:c2) # c2 is in SSDR department
+    department_for_role = contractor_request.department
+    unit_for_role = units(:one)
+    with_temp_user(departments: [department_for_role.code], units: [unit_for_role.code]) do |temp_user|
+      run_as_user(temp_user) do
+        unit_role_cutoff = role_cutoffs(:unit)
+        unit_role_cutoff.cutoff_date = 1.day.from_now
+        unit_role_cutoff.save!
+
+        get edit_contractor_request_path(contractor_request)
+
+        # Verify department options
+        expected_options = [unit_for_role.department.name, contractor_request.department.name]
+        verify_options(response, 'contractor_request_department_id', expected_options)
+
+        # Verify unit options
+        expected_options = [unit_for_role.name]
+        verify_options(response, 'contractor_request_unit_id', expected_options)
+
+        unit_role_cutoff = role_cutoffs(:unit)
+        unit_role_cutoff.cutoff_date = 1.day.ago
+        unit_role_cutoff.save!
+
+        get edit_contractor_request_path(contractor_request)
+
+        # Verify department options - should no longer include department for unit
+        expected_options = [contractor_request.department.name]
+        verify_options(response, 'contractor_request_department_id', expected_options)
+
+        # Verify unit options - should have no options
+        expected_options = []
+        verify_options(response, 'contractor_request_unit_id', expected_options)
+      end
     end
   end
 end

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
-require 'integration/personnel_request_index_test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the ContractorRequest index page
 class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
-  include PersonnelRequestIndexTestHelper
+  include PersonnelRequestsTestHelper
 
   test 'currency field values show with two decimal places' do
     get contractor_requests_path

--- a/test/integration/labor_requests_edit_test.rb
+++ b/test/integration/labor_requests_edit_test.rb
@@ -8,10 +8,6 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
   def setup
     @labor_request = labor_requests(:fac_hrly_renewal)
     @division1 = divisions_with_records[0]
-    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
-    Role.create!(user: @division1_user,
-                 role_type: RoleType.find_by_code('division'),
-                 division: @division1)
   end
 
   test 'currency field values show with two decimal places' do
@@ -26,25 +22,24 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test '"Edit" button should only be shown if policy allows edit' do
-    run_as_user(@division1_user) do
-      labor_requests_all = LaborRequest.all
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        labor_requests_all = LaborRequest.all
 
-      labor_requests_all.each do |r|
-        get labor_request_path(r)
-        if Pundit.policy!(@division1_user, r).edit?
-          assert_select "[id='button_edit']", 1,
-                        "'#{@division1.code}' user could NOT edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
-        else
-          assert_select "[id='button_edit']", 0,
-                        "'#{@division1.code}' user could edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
+        labor_requests_all.each do |r|
+          get labor_request_path(r)
+          if Pundit.policy!(temp_user, r).edit?
+            assert_select "[id='button_edit']", 1,
+                          "'#{@division1.code}' user could NOT edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          else
+            assert_select "[id='button_edit']", 0,
+                          "'#{@division1.code}' user could edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          end
         end
       end
     end
-
-    Role.destroy_all(user: @division1_user)
-    @division1_user.destroy!
   end
 
   test 'can edit review_status or review_comments' do
@@ -54,10 +49,12 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test 'Non-admins cannot edit review_status or review_comments' do
-    run_as_user(@division1_user) do
-      get edit_labor_request_path(@labor_request)
-      assert_select "select#labor_request_review_status_id[disabled='disabled']"
-      assert_select "textarea#labor_request_review_comment[disabled='disabled']"
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        get edit_labor_request_path(@labor_request)
+        assert_select "select#labor_request_review_status_id[disabled='disabled']"
+        assert_select "textarea#labor_request_review_comment[disabled='disabled']"
+      end
     end
   end
 

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
-require 'integration/personnel_request_index_test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the LaborRequest index page
 class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
-  include PersonnelRequestIndexTestHelper
+  include PersonnelRequestsTestHelper
 
   test 'currency field values show with two decimal places' do
     get labor_requests_path

--- a/test/integration/personnel_request_policy_integration_test.rb
+++ b/test/integration/personnel_request_policy_integration_test.rb
@@ -5,16 +5,9 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
   def setup
     @dept1 = departments_with_records[0]
     @dept2 = departments_with_records[1]
-
-    @dept1_user = User.create(cas_directory_id: 'dept1', name: 'Dept1 User')
-    Role.create!(user: @dept1_user,
-                 role_type: RoleType.find_by_code('department'),
-                 department: @dept1)
   end
 
   def teardown
-    Role.destroy_all(user: @dept1_user)
-    @dept1_user.destroy!
   end
 
   # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
@@ -29,71 +22,73 @@ class PersonnelRequestPolicyIntegrationTest < ActionDispatch::IntegrationTest
 
     dept1_request = LaborRequest.where(department: @dept1)[0]
     dept2_request = LaborRequest.where(department: @dept2)[0]
-    run_as_user(@dept1_user) do
-      # Show
-      get labor_request_path(dept1_request)
-      assert_response :success
+    with_temp_user(departments: [@dept1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        # Show
+        get labor_request_path(dept1_request)
+        assert_response :success
 
-      get labor_request_path(dept2_request)
-      assert_response :forbidden
+        get labor_request_path(dept2_request)
+        assert_response :forbidden
 
-      # New
-      get new_labor_request_path
-      assert_response :success
+        # New
+        get new_labor_request_path
+        assert_response :success
 
-      # Edit
-      get edit_labor_request_path(dept1_request)
-      assert_response :success
+        # Edit
+        get edit_labor_request_path(dept1_request)
+        assert_response :success
 
-      get edit_labor_request_path(dept2_request)
-      assert_response :forbidden
+        get edit_labor_request_path(dept2_request)
+        assert_response :forbidden
 
-      # Create
-      post labor_requests_path, labor_request: {
-        contractor_name: dept1_request.contractor_name,
-        department_id: dept1_request.department_id,
-        employee_type_id: dept1_request.employee_type_id,
-        hourly_rate: dept1_request.hourly_rate,
-        hours_per_week: dept1_request.hours_per_week,
-        justification: dept1_request.justification,
-        nonop_funds: dept1_request.nonop_funds,
-        nonop_source: dept1_request.nonop_source,
-        number_of_positions: dept1_request.number_of_positions,
-        number_of_weeks: dept1_request.number_of_weeks,
-        position_description: dept1_request.position_description,
-        request_type_id: dept1_request.request_type_id,
-        unit_id: dept1_request.unit_id }
-      assert_redirected_to labor_request_path(assigns(:labor_request))
+        # Create
+        post labor_requests_path, labor_request: {
+          contractor_name: dept1_request.contractor_name,
+          department_id: dept1_request.department_id,
+          employee_type_id: dept1_request.employee_type_id,
+          hourly_rate: dept1_request.hourly_rate,
+          hours_per_week: dept1_request.hours_per_week,
+          justification: dept1_request.justification,
+          nonop_funds: dept1_request.nonop_funds,
+          nonop_source: dept1_request.nonop_source,
+          number_of_positions: dept1_request.number_of_positions,
+          number_of_weeks: dept1_request.number_of_weeks,
+          position_description: dept1_request.position_description,
+          request_type_id: dept1_request.request_type_id,
+          unit_id: dept1_request.unit_id }
+        assert_redirected_to labor_request_path(assigns(:labor_request))
 
-      post labor_requests_path, labor_request: {
-        contractor_name: dept2_request.contractor_name,
-        department_id: dept2_request.department_id,
-        employee_type_id: dept2_request.employee_type_id,
-        hourly_rate: dept2_request.hourly_rate,
-        hours_per_week: dept2_request.hours_per_week,
-        justification: dept2_request.justification,
-        nonop_funds: dept2_request.nonop_funds,
-        nonop_source: dept2_request.nonop_source,
-        number_of_positions: dept2_request.number_of_positions,
-        number_of_weeks: dept2_request.number_of_weeks,
-        position_description: dept2_request.position_description,
-        request_type_id: dept2_request.request_type_id,
-        unit_id: dept2_request.unit_id }
-      assert_response :forbidden
+        post labor_requests_path, labor_request: {
+          contractor_name: dept2_request.contractor_name,
+          department_id: dept2_request.department_id,
+          employee_type_id: dept2_request.employee_type_id,
+          hourly_rate: dept2_request.hourly_rate,
+          hours_per_week: dept2_request.hours_per_week,
+          justification: dept2_request.justification,
+          nonop_funds: dept2_request.nonop_funds,
+          nonop_source: dept2_request.nonop_source,
+          number_of_positions: dept2_request.number_of_positions,
+          number_of_weeks: dept2_request.number_of_weeks,
+          position_description: dept2_request.position_description,
+          request_type_id: dept2_request.request_type_id,
+          unit_id: dept2_request.unit_id }
+        assert_response :forbidden
 
-      # Update
-      patch labor_request_path(dept1_request), labor_request: { position_description: 'Foo' }
-      assert_redirected_to labor_request_path(dept1_request)
+        # Update
+        patch labor_request_path(dept1_request), labor_request: { position_description: 'Foo' }
+        assert_redirected_to labor_request_path(dept1_request)
 
-      patch labor_request_path(dept2_request), labor_request: { position_description: 'Foo' }
-      assert_response :forbidden
+        patch labor_request_path(dept2_request), labor_request: { position_description: 'Foo' }
+        assert_response :forbidden
 
-      # Destroy
-      delete labor_request_path(dept1_request)
-      assert_redirected_to labor_requests_url
+        # Destroy
+        delete labor_request_path(dept1_request)
+        assert_redirected_to labor_requests_url
 
-      delete labor_request_path(dept2_request)
-      assert_response :forbidden
+        delete labor_request_path(dept2_request)
+        assert_response :forbidden
+      end
     end
   end
 end

--- a/test/integration/personnel_requests_test_helper.rb
+++ b/test/integration/personnel_requests_test_helper.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-# Holds common methods for testing the personnel request index pages.
-module PersonnelRequestIndexTestHelper
+# Holds common methods for testing the personnel request pages.
+module PersonnelRequestsTestHelper
   # Verifies that the given currency fields only display two digits after the
   # decimal point.
   #

--- a/test/integration/personnel_requests_test_helper.rb
+++ b/test/integration/personnel_requests_test_helper.rb
@@ -19,4 +19,17 @@ module PersonnelRequestsTestHelper
       end
     end
   end
+
+  # Verifies the options in a drop-down with the given id from the given
+  # response by comparing them to the expected options text.
+  #
+  # response - a response to a page request
+  # select_id - the "id" of an HTML "select" element
+  # expected_options_text - the text that should be displayed in the options.
+  def verify_options(response, select_id, expected_options_text)
+    doc = Nokogiri::HTML(response.body)
+    options = doc.xpath("//select[@id='#{select_id}']/option")
+    options_text = options.map(&:text)
+    assert_equal expected_options_text.sort, options_text.sort
+  end
 end

--- a/test/integration/staff_requests_edit_test.rb
+++ b/test/integration/staff_requests_edit_test.rb
@@ -8,10 +8,6 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
   def setup
     @staff_request = staff_requests(:fac)
     @division1 = divisions_with_records[0]
-    @division1_user = User.create(cas_directory_id: 'division1', name: 'Division1 User')
-    Role.create!(user: @division1_user,
-                 role_type: RoleType.find_by_code('division'),
-                 division: @division1)
   end
 
   test 'currency field values show with two decimal places' do
@@ -26,25 +22,24 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test '"Edit" button should only be shown if policy allows edit' do
-    run_as_user(@division1_user) do
-      staff_requests_all = StaffRequest.all
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        staff_requests_all = StaffRequest.all
 
-      staff_requests_all.each do |r|
-        get staff_request_path(r)
-        if Pundit.policy!(@division1_user, r).edit?
-          assert_select "[id='button_edit']", 1,
-                        "'#{@division1.code}' user could NOT edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
-        else
-          assert_select "[id='button_edit']", 0,
-                        "'#{@division1.code}' user could edit " \
-                        "'#{r.id}' with division '#{r.department.division.code}'"
+        staff_requests_all.each do |r|
+          get staff_request_path(r)
+          if Pundit.policy!(temp_user, r).edit?
+            assert_select "[id='button_edit']", 1,
+                          "'#{@division1.code}' user could NOT edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          else
+            assert_select "[id='button_edit']", 0,
+                          "'#{@division1.code}' user could edit " \
+                          "'#{r.id}' with division '#{r.department.division.code}'"
+          end
         end
       end
     end
-
-    Role.destroy_all(user: @division1_user)
-    @division1_user.destroy!
   end
 
   test 'can edit review_status or review_comments' do
@@ -54,10 +49,12 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
   end
 
   test 'Non-admins cannot edit review_status or review_comments' do
-    run_as_user(@division1_user) do
-      get edit_staff_request_path(@staff_request)
-      assert_select "select#staff_request_review_status_id[disabled='disabled']"
-      assert_select "textarea#staff_request_review_comment[disabled='disabled']"
+    with_temp_user(divisions: [@division1.code]) do |temp_user|
+      run_as_user(temp_user) do
+        get edit_staff_request_path(@staff_request)
+        assert_select "select#staff_request_review_status_id[disabled='disabled']"
+        assert_select "textarea#staff_request_review_comment[disabled='disabled']"
+      end
     end
   end
 

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
-require 'integration/personnel_request_index_test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the StaffRequest index page
 class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
-  include PersonnelRequestIndexTestHelper
+  include PersonnelRequestsTestHelper
 
   test 'currency field values show with two decimal places' do
     get staff_requests_path


### PR DESCRIPTION
Limits the entries in the "Department" and "Unit" drop-downs for personnel requests, based on the user's roles, and role cutoffs.

Selectable departments/units are controlled by the "selectable_departments" and "selectable_units" methods in PersonnelRequestPolicy.

Departments and units for the drop-downs are passed to the views in the "@selectable_departments" and "@selectable_units" variables. The variables are assigned by the "assign_selectable_departments_and_units" method in the PersonnelRequestController module.

Also added a "with_temp_user" closure to test_helper.rb, which eases creation of temporary users with particular roles.

https://issues.umd.edu/browse/LIBITD-441