### PR TITLE
LIBITD-484. Change column heading "Nonop funds" to "Gift/Other Funds"

### DIFF
--- a/app/models/contractor_request.rb
+++ b/app/models/contractor_request.rb
@@ -18,7 +18,7 @@ class ContractorRequest < ActiveRecord::Base
     number_of_months: { label: 'Number of Months' },
     annual_base_pay: {  label: 'Annual Base Pay',
                         decorator: :number_to_currency },
-    nonop_funds: { label: 'Nonop Funds',
+    nonop_funds: { label: ContractorRequest.human_attribute_name('nonop_funds'),
                    decorator: :number_to_currency },
     division__code: { label: 'Division' },
     department__code: { label: 'Department' },

--- a/app/models/labor_request.rb
+++ b/app/models/labor_request.rb
@@ -23,7 +23,7 @@ class LaborRequest < ActiveRecord::Base
     number_of_weeks: { label: 'Numbers of Weeks' },
     annual_cost: {  label: 'Annual Cost',
                     decorator: :number_to_currency },
-    nonop_funds: {  label: 'Nonop Funds',
+    nonop_funds: {  label: LaborRequest.human_attribute_name('nonop_funds'),
                     decorator: :number_to_currency },
     division__code: { label: 'Division' },
     department__code: { label: 'Department' },

--- a/app/models/staff_request.rb
+++ b/app/models/staff_request.rb
@@ -13,7 +13,7 @@ class StaffRequest < ActiveRecord::Base
     request_type__code: { label: 'Request Type' },
     annual_base_pay: {  label: 'Annual Base Pay',
                         decorator: :number_to_currency },
-    nonop_funds: {  label: 'Nonop Funds',
+    nonop_funds: {  label: StaffRequest.human_attribute_name('nonop_funds'),
                     decorator: :number_to_currency },
     division__code: { label: 'Division' },
     department__code: { label: 'Department' },

--- a/app/views/contractor_requests/show.html.erb
+++ b/app/views/contractor_requests/show.html.erb
@@ -35,12 +35,12 @@
     </tr>
 
     <tr>
-      <th>Nonop funds</th>
+      <th><%= ContractorRequest.human_attribute_name('nonop_funds') %></th>
       <td id="nonop_funds"><%= number_to_currency(@contractor_request.nonop_funds) %></td>
     </tr>
 
     <tr>
-      <th>Nonop source</th>
+      <th><%=  ContractorRequest.human_attribute_name('nonop_source') %></th>
       <td id="nonop_source"><%= @contractor_request.nonop_source %></td>
     </tr>
 

--- a/app/views/labor_requests/show.html.erb
+++ b/app/views/labor_requests/show.html.erb
@@ -50,12 +50,12 @@
     </tr>
 
     <tr>
-      <th>Nonop funds:</th>
+      <th><%= LaborRequest.human_attribute_name('nonop_funds') %></th>
       <td id="nonop_funds"><%= number_to_currency(@labor_request.nonop_funds) %></td>
     </tr>
 
     <tr>
-      <th>Nonop source:</th>
+      <th><%= LaborRequest.human_attribute_name('nonop_source') %></th>
       <td id="nonop_source"><%= @labor_request.nonop_source %></td>
     </tr>
 

--- a/app/views/staff_requests/show.html.erb
+++ b/app/views/staff_requests/show.html.erb
@@ -25,12 +25,12 @@
     </tr>
 
     <tr>
-      <th>Nonop funds:</th>
+      <th><%= StaffRequest.human_attribute_name('nonop_funds') %></th>
       <td id="nonop_funds"><%= number_to_currency(@staff_request.nonop_funds) %></td>
     </tr>
 
     <tr>
-      <th>Nonop source:</th>
+      <th><%= StaffRequest.human_attribute_name('nonop_source') %></th>
       <td id="nonop_source"><%= @staff_request.nonop_source %></td>
     </tr>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,9 +20,22 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
-  hello: "Hello world"
+  dictionary: 
+    personnel_request:
+      nonop_funds: &nonop_funds Gift/Other Funds
+      nonop_source: &nonop_source Gift/Other Funds source
   
   activerecord:
     attributes:
       user:
         cas_directory_id: CAS Directory ID
+      contractor_request:
+        nonop_funds: *nonop_funds
+        nonop_source: *nonop_source
+      labor_request:
+        nonop_funds: *nonop_funds
+        nonop_source: *nonop_source
+      staff_request:
+        nonop_funds: *nonop_funds
+        nonop_source: *nonop_source
+        

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -111,4 +111,18 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get edit_contractor_request_path(@contractor_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.contractor_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'label[for=?]', 'contractor_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'label[for=?]', 'contractor_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -114,15 +114,9 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get edit_contractor_request_path(@contractor_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.contractor_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'label[for=?]', 'contractor_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'label[for=?]', 'contractor_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label("label[for='contractor_request_nonop_funds']",
+                      'activerecord.attributes.contractor_request.nonop_funds')
+    verify_i18n_label("label[for='contractor_request_nonop_source']",
+                      'activerecord.attributes.contractor_request.nonop_source')
   end
 end

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -141,9 +141,6 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds label should be internationalized' do
     get contractor_requests_path
-    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    verify_i18n_label('th#nonop_funds', 'activerecord.attributes.contractor_request.nonop_funds')
   end
 end

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -138,4 +138,12 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
     assert_not review_status_texts.include?(review_statuses(:under_review).name)
     assert review_status_texts.include?('')
   end
+
+  test 'nonop funds label should be internationalized' do
+    get contractor_requests_path
+    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+  end
 end

--- a/test/integration/contractor_requests_show_test.rb
+++ b/test/integration/contractor_requests_show_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the ContractorRequest show page
 class ContractorRequestsShowTest < ActionDispatch::IntegrationTest
+  include PersonnelRequestsTestHelper
+
   def setup
     @contractor_request = contractor_requests(:cont_fac_renewal)
   end
@@ -19,15 +22,7 @@ class ContractorRequestsShowTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get contractor_request_path(@contractor_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.contractor_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label('th', 'activerecord.attributes.contractor_request.nonop_funds')
+    verify_i18n_label('th', 'activerecord.attributes.contractor_request.nonop_source')
   end
 end

--- a/test/integration/contractor_requests_show_test.rb
+++ b/test/integration/contractor_requests_show_test.rb
@@ -16,4 +16,18 @@ class ContractorRequestsShowTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get contractor_request_path(@contractor_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.contractor_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.contractor_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/labor_requests_edit_test.rb
+++ b/test/integration/labor_requests_edit_test.rb
@@ -114,15 +114,7 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get edit_labor_request_path(@labor_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.labor_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'label[for=?]', 'labor_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'label[for=?]', 'labor_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label("label[for='labor_request_nonop_funds']", 'activerecord.attributes.labor_request.nonop_funds')
+    verify_i18n_label("label[for='labor_request_nonop_source']", 'activerecord.attributes.labor_request.nonop_source')
   end
 end

--- a/test/integration/labor_requests_edit_test.rb
+++ b/test/integration/labor_requests_edit_test.rb
@@ -111,4 +111,18 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get edit_labor_request_path(@labor_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.labor_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'label[for=?]', 'labor_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'label[for=?]', 'labor_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -163,9 +163,6 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds label should be internationalized' do
     get labor_requests_path
-    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    verify_i18n_label('th#nonop_funds', 'activerecord.attributes.labor_request.nonop_funds')
   end
 end

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -160,4 +160,12 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
     assert_not review_status_texts.include?(review_statuses(:under_review).name)
     assert review_status_texts.include?('')
   end
+
+  test 'nonop funds label should be internationalized' do
+    get labor_requests_path
+    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+  end
 end

--- a/test/integration/labor_requests_show_test.rb
+++ b/test/integration/labor_requests_show_test.rb
@@ -21,4 +21,18 @@ class LaborRequestsShowTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get labor_request_path(@labor_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.labor_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/labor_requests_show_test.rb
+++ b/test/integration/labor_requests_show_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the LaborRequest show page
 class LaborRequestsShowTest < ActionDispatch::IntegrationTest
+  include PersonnelRequestsTestHelper
+
   def setup
     @labor_request = labor_requests(:fac_hrly_renewal)
   end
@@ -24,15 +27,7 @@ class LaborRequestsShowTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get labor_request_path(@labor_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.labor_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.labor_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label('th', 'activerecord.attributes.labor_request.nonop_funds')
+    verify_i18n_label('th', 'activerecord.attributes.labor_request.nonop_source')
   end
 end

--- a/test/integration/personnel_requests_test_helper.rb
+++ b/test/integration/personnel_requests_test_helper.rb
@@ -32,4 +32,19 @@ module PersonnelRequestsTestHelper
     options_text = options.map(&:text)
     assert_equal expected_options_text.sort, options_text.sort
   end
+
+  # Verifies that the given i18n_key exists, and that the text for the
+  # given selector matches the text for the i18n_key
+  #
+  # This method assumes that a "response" object containing the page response
+  # exists.
+  #
+  # selector - the selector passed to 'assert_select' for finding the text
+  # i18n_key - the I18N key for retrieving the expected text. The key must
+  #   exist in localization file.
+  def verify_i18n_label(selector, i18n_key)
+    assert I18n.exists?(i18n_key, :en)
+    assert_select selector, { count: 1, text: I18n.t(i18n_key) },
+                  "No label matching '#{I18n.t(i18n_key)}' was found."
+  end
 end

--- a/test/integration/staff_requests_edit_test.rb
+++ b/test/integration/staff_requests_edit_test.rb
@@ -114,15 +114,7 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get edit_staff_request_path(@staff_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.staff_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'label[for=?]', 'staff_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'label[for=?]', 'staff_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label("label[for='staff_request_nonop_funds']", 'activerecord.attributes.staff_request.nonop_funds')
+    verify_i18n_label("label[for='staff_request_nonop_source']", 'activerecord.attributes.staff_request.nonop_source')
   end
 end

--- a/test/integration/staff_requests_edit_test.rb
+++ b/test/integration/staff_requests_edit_test.rb
@@ -111,4 +111,18 @@ class StaffRequestsEditTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get edit_staff_request_path(@staff_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.staff_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'label[for=?]', 'staff_request_nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'label[for=?]', 'staff_request_nonop_source', { text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -138,4 +138,12 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
     assert_not review_status_texts.include?(review_statuses(:under_review).name)
     assert review_status_texts.include?('')
   end
+
+  test 'nonop funds label should be internationalized' do
+    get staff_requests_path
+    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+  end
 end

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -141,9 +141,6 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds label should be internationalized' do
     get staff_requests_path
-    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert_select 'th#nonop_funds', { text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    verify_i18n_label('th#nonop_funds', 'activerecord.attributes.staff_request.nonop_funds')
   end
 end

--- a/test/integration/staff_requests_show_test.rb
+++ b/test/integration/staff_requests_show_test.rb
@@ -16,4 +16,18 @@ class StaffRequestsShowTest < ActionDispatch::IntegrationTest
       end
     end
   end
+
+  test 'nonop funds labels should be internationalized' do
+    get staff_request_path(@staff_request)
+    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
+    nonop_source_i18n_key = 'activerecord.attributes.staff_request.nonop_source'
+
+    assert I18n.exists?(nonop_funds_i18n_key, :en)
+    assert I18n.exists?(nonop_source_i18n_key, :en)
+
+    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
+    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
+                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+  end
 end

--- a/test/integration/staff_requests_show_test.rb
+++ b/test/integration/staff_requests_show_test.rb
@@ -1,7 +1,10 @@
 require 'test_helper'
+require 'integration/personnel_requests_test_helper'
 
 # Integration test for the StaffRequest show page
 class StaffRequestsShowTest < ActionDispatch::IntegrationTest
+  include PersonnelRequestsTestHelper
+
   def setup
     @staff_request = staff_requests(:fac)
   end
@@ -19,15 +22,7 @@ class StaffRequestsShowTest < ActionDispatch::IntegrationTest
 
   test 'nonop funds labels should be internationalized' do
     get staff_request_path(@staff_request)
-    nonop_funds_i18n_key = 'activerecord.attributes.staff_request.nonop_funds'
-    nonop_source_i18n_key = 'activerecord.attributes.staff_request.nonop_source'
-
-    assert I18n.exists?(nonop_funds_i18n_key, :en)
-    assert I18n.exists?(nonop_source_i18n_key, :en)
-
-    assert_select 'th', { count: 1, text: I18n.t(nonop_funds_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_funds_i18n_key)}' was found."
-    assert_select 'th', { count: 1, text: I18n.t(nonop_source_i18n_key) },
-                  "No label matching '#{I18n.t(nonop_source_i18n_key)}' was found."
+    verify_i18n_label('th', 'activerecord.attributes.staff_request.nonop_funds')
+    verify_i18n_label('th', 'activerecord.attributes.staff_request.nonop_source')
   end
 end


### PR DESCRIPTION
Modified "Nonop funds" and "Nonop source" to use an internationalized label, and then changed
the i18n text.

https://issues.umd.edu/browse/LIBITD-484