### PR TITLE
LIBITD-499. Integrate simplecov test coverage reports into Jenkins

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -80,6 +80,7 @@ group :test do
   gem 'rubocop', '~> 0.39.0', require: false
   gem 'rubocop-checkstyle_formatter', '~> 0.2.0', require: false
   gem 'simplecov', require: false
+  gem 'simplecov-rcov', require: false
 
   # for checking the excel files
   gem 'roo'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,8 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
+    simplecov-rcov (0.2.3)
+      simplecov (>= 0.4.1)
     spreadsheet (1.1.3)
       ruby-ole (>= 1.0)
     spring (1.6.4)
@@ -250,6 +252,7 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   simplecov
+  simplecov-rcov
   spring
   sqlite3
   turbolinks

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,9 @@
 require 'simplecov'
+require 'simplecov-rcov'
+SimpleCov.formatters = [
+  SimpleCov::Formatter::HTMLFormatter,
+  SimpleCov::Formatter::RcovFormatter
+]
 SimpleCov.start
 
 ENV['RAILS_ENV'] ||= 'test'


### PR DESCRIPTION
Added simplecov-rcov to enable Jenkins to parse coverage

https://issues.umd.edu/browse/LIBITD-499