### PR TITLE
LIBITD-510 Refactor fields from model to view helper

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,4 @@
 module ApplicationHelper
-  # simply removes the status if it is "UnderReview"
-  def suppress_status(status)
-    status == 'Under Review' ? '' : status
-  end
-
   # Returns HTML content for a tooltip displaying the given translation key,
   # or nil if the translation key is not set.
   def help_text_icon(translation_key)

--- a/app/helpers/personnel_requests_helper.rb
+++ b/app/helpers/personnel_requests_helper.rb
@@ -1,5 +1,4 @@
 module PersonnelRequestsHelper
-  
   # Returns a list of fields for a record
   #
   # @param klass [Class] the active record klass being displayed
@@ -14,7 +13,7 @@ module PersonnelRequestsHelper
   #
   # @param record [ActiveRecord] the record with the field
   # @param field [Symbol] the field name ( use __ to indicate associations )
-  # @return [String] value from record field 
+  # @return [String] value from record field
   def call_record_field(record, field)
     method = "render_#{field}".intern
     if respond_to? method
@@ -32,8 +31,8 @@ module PersonnelRequestsHelper
   # Formats review status based on the codey
   # @param record [ActiveRecord] the record to be called
   def render_review_status__name(record)
-    if record.review_status.code == "UnderReview"
-      ""
+    if record.review_status.code == 'UnderReview'
+      ''
     else
       record.call_field(:review_status__name)
     end
@@ -48,7 +47,7 @@ module PersonnelRequestsHelper
         nonop_funds division__code department__code unit__code review_status__name
       )
   end
-  
+
   # Returns an array of the fields used in staff_requests
   #
   # @return [Array] list of fields
@@ -57,7 +56,7 @@ module PersonnelRequestsHelper
         nonop_funds division__code department__code unit__code review_status__name
       )
   end
-  
+
   # Returns an array of the fields used in contractor_requests
   #
   # @return [Array] list of fields

--- a/app/helpers/personnel_requests_helper.rb
+++ b/app/helpers/personnel_requests_helper.rb
@@ -1,0 +1,69 @@
+module PersonnelRequestsHelper
+  
+  # Returns a list of fields for a record
+  #
+  # @param klass [Class] the active record klass being displayed
+  # @return [Array] the list of fields being displayed
+  def fields(klass)
+    send(:"#{klass.to_s.underscore}_fields")
+  end
+
+  # Calls the field on the record and attempts to display it.
+  # If there is special formatting on the field, define a "render_FIELD_NAME"
+  # method that takes the record and tweaks the field
+  #
+  # @param record [ActiveRecord] the record with the field
+  # @param field [Symbol] the field name ( use __ to indicate associations )
+  # @return [String] value from record field 
+  def call_record_field(record, field)
+    method = "render_#{field}".intern
+    if respond_to? method
+      send(method, record)
+    else
+      record.call_field(field)
+    end
+  end
+
+  # these are the fields that we want to render into a currency
+  %w( nonop_funds annual_cost annual_base_pay hourly_rate  ).each do |m|
+    define_method("render_#{m}".intern) { |r| number_to_currency r.call_field(m.intern) }
+  end
+
+  # Formats review status based on the codey
+  # @param record [ActiveRecord] the record to be called
+  def render_review_status__name(record)
+    if record.review_status.code == "UnderReview"
+      ""
+    else
+      record.call_field(:review_status__name)
+    end
+  end
+
+  # Returns an array of the fields used in labor_requests
+  #
+  # @return [Array] list of fields
+  def labor_request_fields
+    %i( position_description employee_type__code request_type__code contractor_name
+        number_of_positions hourly_rate hours_per_week number_of_weeks annual_cost
+        nonop_funds division__code department__code unit__code review_status__name
+      )
+  end
+  
+  # Returns an array of the fields used in staff_requests
+  #
+  # @return [Array] list of fields
+  def staff_request_fields
+    %i( position_description employee_type__code request_type__code annual_base_pay
+        nonop_funds division__code department__code unit__code review_status__name
+      )
+  end
+  
+  # Returns an array of the fields used in contractor_requests
+  #
+  # @return [Array] list of fields
+  def contractor_request_fields
+    %i( position_description employee_type__code request_type__code contractor_name
+        number_of_months annual_base_pay nonop_funds division__code department__code
+        unit__code review_status__name )
+  end
+end

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -27,17 +27,8 @@ module Requestable
     end
   end
 
-  # Returns an array that can be used to generate index/xslx views
-  # to set this up, each key is callable on the object. to chain methods,
-  # use a double _ ( e.g. labor_request.request_type.code = request_type__code )
-  def self.fields
-    {}
-  end
-
   # method to call the fields expressed in .fields
   def call_field(field)
-    field = field.to_sym
-    return nil unless self.class.fields.include?(field)
     field.to_s.split('__').inject(self) { |a, e| a.send(e) unless a.nil? }
   end
 end

--- a/app/models/contractor_request.rb
+++ b/app/models/contractor_request.rb
@@ -10,23 +10,6 @@ class ContractorRequest < ActiveRecord::Base
   validates :annual_base_pay, presence: true
   validates_with RequestDepartmentValidator
 
-  FIELDS = {
-    position_description: { label: 'Position Description' },
-    employee_type__code: { label: 'Employee Type' },
-    request_type__code: { label: 'Request Type' },
-    contractor_name: { label: 'Contractor Name' },
-    number_of_months: { label: 'Number of Months' },
-    annual_base_pay: {  label: 'Annual Base Pay',
-                        decorator: :number_to_currency },
-    nonop_funds: { label: ContractorRequest.human_attribute_name('nonop_funds'),
-                   decorator: :number_to_currency },
-    division__code: { label: 'Division' },
-    department__code: { label: 'Department' },
-    unit__code: { label: 'Unit' },
-    review_status__name: { label: 'Review Status',
-                           decorator: :suppress_status }
-  }.freeze
-
   after_initialize :init
 
   def init
@@ -38,13 +21,6 @@ class ContractorRequest < ActiveRecord::Base
     unless VALID_REQUEST_TYPE_CODES.include?(request_type.try(:code))
       errors.add(:request_type, 'Not an allowed request type for this request.')
     end
-  end
-
-  # Returns an array that can be used to generate index/xslx views
-  # to set this up, each key is callable on the object. to chain methods,
-  # use a double _ ( e.g. labor_request.request_type.code = request_type__code )
-  def self.fields
-    FIELDS
   end
 
   # Returns true if the contractor name is required.

--- a/app/models/labor_request.rb
+++ b/app/models/labor_request.rb
@@ -11,27 +11,6 @@ class LaborRequest < ActiveRecord::Base
   validates :hours_per_week, presence: true, numericality: { greater_than: 0.00 }
   validates :number_of_weeks, presence: true, numericality: { only_integer: true, greater_than: 0 }
 
-  FIELDS = {
-    position_description: { label: 'Position Description' },
-    employee_type__code: { label: 'Employee Type' },
-    request_type__code: { label: 'Request Type' },
-    contractor_name: { label: 'Contractor Name' },
-    number_of_positions: { label: 'Number of Positions' },
-    hourly_rate: {  label: 'Hourly Rate',
-                    decorator: :number_to_currency },
-    hours_per_week: { label: 'Hours per Week' },
-    number_of_weeks: { label: 'Numbers of Weeks' },
-    annual_cost: {  label: 'Annual Cost',
-                    decorator: :number_to_currency },
-    nonop_funds: {  label: LaborRequest.human_attribute_name('nonop_funds'),
-                    decorator: :number_to_currency },
-    division__code: { label: 'Division' },
-    department__code: { label: 'Department' },
-    unit__code: { label: 'Unit' },
-    review_status__name: { label: 'Review Status',
-                           decorator: :suppress_status }
-  }.freeze
-
   after_initialize :init
 
   def init
@@ -43,13 +22,6 @@ class LaborRequest < ActiveRecord::Base
     unless VALID_REQUEST_TYPE_CODES.include?(request_type.try(:code))
       errors.add(:request_type, 'Not an allowed request type for this request.')
     end
-  end
-
-  # Returns an array that can be used to generate index/xslx views
-  # to set this up, each key is callable on the object. to chain methods,
-  # use a double _ ( e.g. labor_request.request_type.code = request_type__code )
-  def self.fields
-    FIELDS
   end
 
   # Returns true if the contractor name is required.

--- a/app/models/reports/requests_by_type_report.rb
+++ b/app/models/reports/requests_by_type_report.rb
@@ -16,20 +16,13 @@ class RequestsByTypeReport
       [StaffRequest.enum_for(:find_each), ContractorRequest.enum_for(:find_each), LaborRequest.enum_for(:find_each)]
     end
 
-    def fields
-      { "StaffRequests": StaffRequest.fields,
-        "ContractorRequests": ContractorRequest.fields,
-        "LaborRequests": LaborRequest.fields
-       }.with_indifferent_access
-    end
-
     def formats
       %w( xlsx )
     end
 
     # Here you add your worksheet tit to be made in the report
     def worksheets
-      %w( StaffRequests ContractorRequests LaborRequests )
+      %w( StaffRequest ContractorRequest LaborRequest )
     end
   end
 end

--- a/app/models/staff_request.rb
+++ b/app/models/staff_request.rb
@@ -7,21 +7,6 @@ class StaffRequest < ActiveRecord::Base
 
   validates :annual_base_pay, presence: true
 
-  FIELDS = {
-    position_description: { label: 'Position Description' },
-    employee_type__code: { label: 'Employee Type' },
-    request_type__code: { label: 'Request Type' },
-    annual_base_pay: {  label: 'Annual Base Pay',
-                        decorator: :number_to_currency },
-    nonop_funds: {  label: StaffRequest.human_attribute_name('nonop_funds'),
-                    decorator: :number_to_currency },
-    division__code: { label: 'Division' },
-    department__code: { label: 'Department' },
-    unit__code: { label: 'Unit' },
-    review_status__name: { label: 'Review Status',
-                           decorator: :suppress_status }
-  }.freeze
-
   after_initialize :init
 
   def init
@@ -33,9 +18,5 @@ class StaffRequest < ActiveRecord::Base
     unless VALID_REQUEST_TYPE_CODES.include?(request_type.try(:code))
       errors.add(:request_type, 'provided is not allowed for this request.')
     end
-  end
-
-  def self.fields
-    FIELDS
   end
 end

--- a/app/views/contractor_requests/index.html.erb
+++ b/app/views/contractor_requests/index.html.erb
@@ -3,6 +3,6 @@
 </div>
 
 <%= render partial: 'shared/index_action_buttons',
-  locals: { model_type: ContractorRequest, pagination_object: @contractor_requests } %>
-<%= render partial: 'shared/table', locals: { model_type: ContractorRequest,  records: @contractor_requests } %>
+  locals: { klass: ContractorRequest, pagination_object: @contractor_requests } %>
+<%= render partial: 'shared/table', locals: { klass: ContractorRequest,  records: @contractor_requests } %>
 <%= will_paginate renderer: BootstrapPagination::Rails %>

--- a/app/views/departments/index.html.erb
+++ b/app/views/departments/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Departments</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: Department %>
+<%= render 'shared/index_action_buttons', klass: Department %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/divisions/index.html.erb
+++ b/app/views/divisions/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Divisions</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: Division %>
+<%= render 'shared/index_action_buttons', klass: Division %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/employee_categories/index.html.erb
+++ b/app/views/employee_categories/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Employee Categories</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: EmployeeCategory %>
+<%= render 'shared/index_action_buttons', klass: EmployeeCategory %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/employee_types/index.html.erb
+++ b/app/views/employee_types/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Employee Types</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: EmployeeType %>
+<%= render 'shared/index_action_buttons', klass: EmployeeType %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/labor_requests/index.html.erb
+++ b/app/views/labor_requests/index.html.erb
@@ -3,6 +3,6 @@
 </div>
 
 <%= render partial: 'shared/index_action_buttons',
-  locals: { model_type: LaborRequest, pagination_object: @labor_requests } %>
-<%= render partial: 'shared/table', locals: { model_type: LaborRequest,  records: @labor_requests } %>
+  locals: { klass: LaborRequest, pagination_object: @labor_requests } %>
+<%= render partial: 'shared/table', locals: { klass: LaborRequest,  records: @labor_requests } %>
 <%= will_paginate renderer: BootstrapPagination::Rails %>

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Reports</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: Report %>
+<%= render 'shared/index_action_buttons', klass: Report %>
 <table class="table table-striped">
   <thead>
     <tr>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -1,6 +1,6 @@
 <div class="page-header">
   <h1><%= @report.name.underscore.humanize %> 
-    <div class='pull-right'><%= link_to "Download", report_download_path(@report, format: @report.format), 
+    <div class='pull-right' data-turbolinks='false'><%= link_to "Download", report_download_path(@report, format: @report.format), 
       class: 'btn btn-success' unless @report.output.nil? %></div>
     </h1> 
   </div>

--- a/app/views/request_types/index.html.erb
+++ b/app/views/request_types/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Request Types</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: RequestType %>
+<%= render 'shared/index_action_buttons', klass: RequestType %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/review_statuses/index.html.erb
+++ b/app/views/review_statuses/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Review Status Types</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: ReviewStatus %>
+<%= render 'shared/index_action_buttons', klass: ReviewStatus %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/role_cutoffs/index.html.erb
+++ b/app/views/role_cutoffs/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Role Cutoffs</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: RoleCutoff %>
+<%= render 'shared/index_action_buttons', klass: RoleCutoff %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/role_types/index.html.erb
+++ b/app/views/role_types/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Role Types</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: RoleType %>
+<%= render 'shared/index_action_buttons', klass: RoleType %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/roles/index.html.erb
+++ b/app/views/roles/index.html.erb
@@ -3,7 +3,7 @@
 </div>
 
 <%= render partial: 'shared/index_action_buttons',
-  locals: { model_type: Role, pagination_object: @roles } %>
+  locals: { klass: Role, pagination_object: @roles } %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/shared/_index_action_buttons.erb
+++ b/app/views/shared/_index_action_buttons.erb
@@ -12,11 +12,11 @@
     <div class="btn-group"><%= will_paginate(:renderer => BootstrapPagination::Rails) %></div>
   <% end %>
 
-  <% if policy(model_type).new? %>
-    <div class="btn-group"><%= link_to 'New', new_polymorphic_path(model_type), class: 'btn btn-success', :id => 'toolbar_new' %></div>
+  <% if policy(klass).new? %>
+    <div class="btn-group"><%= link_to 'New', new_polymorphic_path(klass), class: 'btn btn-success', :id => 'toolbar_new' %></div>
   <% end %>    
   <% if  params["controller"] =~ /_requests$/ %>
-    <div class="btn-group"><%= link_to 'Export', params.merge( format: :xlsx ),
+    <div class="btn-group" data-turbolink='false'><%= link_to 'Export', params.merge( format: :xlsx ),
       class: 'btn btn-info', :id => 'export' %></div>
   <% end %>
 

--- a/app/views/shared/_table.html.erb
+++ b/app/views/shared/_table.html.erb
@@ -1,4 +1,4 @@
 <table class="table table-striped">
-  <%= render partial: "shared/table_header", locals: { model_type: model_type } %>
+  <%= render partial: "shared/table_header", locals: { klass: klass } %>
   <%= render partial: "shared/table_body", locals: { records: records }  %> 
 </table>

--- a/app/views/shared/_table_body.html.erb
+++ b/app/views/shared/_table_body.html.erb
@@ -1,12 +1,8 @@
 <tbody>
   <%- records.each do |record| %>
     <tr <%= "style=background-color:#{record.review_status.color};" if record.review_status %> >
-      <%- record.class.fields.each do |field, attrs| %> 
-        <%- if attrs[:decorator] %>
-          <td headers="<%= field.to_s %>"><%= self.send(attrs[:decorator], record.call_field(field) )  %></td>
-        <%- else %>
-          <td headers="<%= field.to_s %>"><%= record.call_field field %></td>
-        <% end %>   
+      <%- fields(record.class).each do |field| %> 
+          <td headers="<%= field.to_s %>"><%= call_record_field record, field %></td>
       <% end %> 
       <%= render 'shared/table_action_buttons', object: record %> 
     </tr>

--- a/app/views/shared/_table_header.html.erb
+++ b/app/views/shared/_table_header.html.erb
@@ -1,8 +1,8 @@
-<thead>
+<thead class='<%= "#{klass.to_s.underscore}_fields" %>'>
   <tr>
-  <%- model_type.fields.each do |field, attrs | %>
-    <th id="<%= field.to_s %>"><%= multi_sort_link(@q, field, attrs[:label] ) %></th>
+  <%- fields(klass).each do |field | %>
+    <th id="<%= field.to_s %>"><%= multi_sort_link( @q, field, klass.human_attribute_name(field) ) %></th>
   <% end %>
-    <%= render 'shared/table_action_buttons_header',  model_type: model_type  %>
+    <%= render 'shared/table_action_buttons_header',  model_type: klass  %>
   </tr>
 </thead>

--- a/app/views/shared/index.xlsx.axlsx
+++ b/app/views/shared/index.xlsx.axlsx
@@ -5,16 +5,14 @@ wb = xlsx_package.workbook
 
 record_set.each_with_index do |records, i|
   name = worksheets[i] ? worksheets[i] : worksheets.first 
-  fields = klass.fields.has_key?(name) ? klass.fields[name] : klass.fields 
-  wb.add_worksheet( name: name ) do |sheet|
-    sheet.add_row [ "Request Type" ] + fields.map { |k,v| v[:label] }
+  wb.add_worksheet( name: name.pluralize ) do |sheet|
+    sheet_klass = name.constantize 
+    fields = fields(sheet_klass) 
+    
+    sheet.add_row [ "Request Type" ] + fields.map { |field| sheet_klass.human_attribute_name( field.to_s.split("__").first.intern ) }
     records.each do |record| 
-      data = [ record.class.to_s.underscore.humanize ] + fields.map do |field, attrs|
-        if attrs[:decorator]
-          self.send( attrs[:decorator], record.call_field(field) )
-        else
-          record.call_field field
-        end
+      data = [ record.class.to_s.underscore.humanize ] + fields.map do |field|
+          call_record_field record, field 
       end
       sheet.add_row data
     end

--- a/app/views/staff_requests/index.html.erb
+++ b/app/views/staff_requests/index.html.erb
@@ -3,6 +3,6 @@
 </div>
 
 <%= render partial: 'shared/index_action_buttons',
-  locals: { model_type: StaffRequest, pagination_object: @staff_requests } %>
-<%= render partial: 'shared/table', locals: { model_type: StaffRequest,  records: @staff_requests } %>
+  locals: { klass: StaffRequest, pagination_object: @staff_requests } %>
+<%= render partial: 'shared/table', locals: { klass: StaffRequest,  records: @staff_requests } %>
 <%= will_paginate renderer: BootstrapPagination::Rails %>

--- a/app/views/units/index.html.erb
+++ b/app/views/units/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Units</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: Unit %>
+<%= render 'shared/index_action_buttons', klass: Unit %>
 
 <table class="table table-striped">
   <thead>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
   <h1>Users</h1>
 </div>
 
-<%= render 'shared/index_action_buttons', model_type: User %>
+<%= render 'shared/index_action_buttons', klass: User %>
 
 <table class="table table-striped">
   <thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,23 +21,25 @@
 
 en:
   dictionary: 
-    personnel_request:
-      nonop_funds: &nonop_funds Gift/Other Funds
-      nonop_source: &nonop_source Gift/Other Funds source
-  
+    personnel_request: &personnel_request
+      nonop_funds: Gift/Other Funds
+      nonop_source: Gift/Other Funds source
+      employee_type__code: Employee Type
+      request_type__code: Request Type
+      division__code: Division
+      department__code: Division
+      unit__code: Unit
+      review_status__name: Review Status
   activerecord:
     attributes:
       user:
         cas_directory_id: CAS Directory ID
       contractor_request:
-        nonop_funds: *nonop_funds
-        nonop_source: *nonop_source
+        <<: *personnel_request 
       labor_request:
-        nonop_funds: *nonop_funds
-        nonop_source: *nonop_source
+        <<: *personnel_request 
       staff_request:
-        nonop_funds: *nonop_funds
-        nonop_source: *nonop_source
+        <<: *personnel_request 
 
   # Help descriptions for fields
   # Can use "&#13;" to denote a line break.

--- a/test/fixtures/.~lock.excel.xlsx#
+++ b/test/fixtures/.~lock.excel.xlsx#
@@ -1,1 +1,0 @@
-,chrisfitzpatrick,chrisfitzpatricks-MacBook-Pro.local,28.09.2016 22:25,file:///Users/chrisfitzpatrick/Library/Application%20Support/LibreOffice/4;

--- a/test/helpers/application_helper_test.rb
+++ b/test/helpers/application_helper_test.rb
@@ -3,11 +3,6 @@ require 'test_helper'
 class ApplicationHelperTest < ActionView::TestCase
   include ApplicationHelper
 
-  def test_suppress_status
-    assert_equal '', suppress_status('Under Review')
-    assert_equal 'Hot', suppress_status('Hot')
-  end
-
   test 'verify help-text-icon content when provided a valid translation key' do
     existing_translation_key = 'help_text.position_description'
     expected_help_test = raw t('help_text.position_description')

--- a/test/helpers/personnel_requests_helper_test.rb
+++ b/test/helpers/personnel_requests_helper_test.rb
@@ -3,31 +3,29 @@ require 'ostruct'
 
 class PersonnelRequestsHelperTest < ActionView::TestCase
   include PersonnelRequestsHelper
-  
+
   def setup
   end
 
   def test_report_formats
     record = contractor_requests(:cont_fac_renewal)
-    assert_equal "", render_review_status__name(record)
-    record.review_status.code = "Boom"
-    record.review_status.name = "BOOM!"
-    assert_equal "BOOM!", render_review_status__name(record)
+    assert_equal '', render_review_status__name(record)
+    record.review_status.code = 'Boom'
+    record.review_status.name = 'BOOM!'
+    assert_equal 'BOOM!', render_review_status__name(record)
   end
 
   def test_currency_formats
     fields = %w( nonop_funds  annual_cost  annual_base_pay  hourly_rate  )
-   
+
     # this abstracts out the ActiveModel class being used
     proxy = OpenStruct.new
-    proxy.define_singleton_method(:call_field) { |field| self.send(field) } 
-    
-    fields.each do |m|
-      val = rand(10000) 
-      proxy.send("#{m}=".intern, val) 
-      assert_equal  number_to_currency( val ), call_record_field( proxy , m )
-    end
-  
-  end
+    proxy.define_singleton_method(:call_field) { |field| send(field) }
 
+    fields.each do |m|
+      val = rand(10_000)
+      proxy.send("#{m}=".intern, val)
+      assert_equal number_to_currency(val), call_record_field(proxy, m)
+    end
+  end
 end

--- a/test/helpers/personnel_requests_helper_test.rb
+++ b/test/helpers/personnel_requests_helper_test.rb
@@ -1,0 +1,32 @@
+require 'test_helper'
+require 'ostruct'
+
+class PersonnelRequestsHelperTest < ActionView::TestCase
+  include PersonnelRequestsHelper
+  
+  def setup
+  end
+
+  def test_report_formats
+    record = contractor_requests(:cont_fac_renewal)
+    assert_equal "", render_review_status__name(record)
+    record.review_status.code = "Boom"
+    record.review_status.name = "BOOM!"
+    assert_equal "BOOM!", render_review_status__name(record)
+  end
+
+  def test_currency_formats
+    fields = %w( nonop_funds  annual_cost  annual_base_pay  hourly_rate  )
+   
+    # this abstracts out the AM class being used
+    thingy = OpenStruct.new
+    thingy.define_singleton_method(:call_field) { |field| self.send(field) } 
+    
+    fields.each do |m|
+      val = rand(10000) 
+      thingy.send("#{m}=".intern, val) 
+      assert_equal  number_to_currency( val ), call_record_field( thingy , m )
+    end
+  end
+
+end

--- a/test/helpers/personnel_requests_helper_test.rb
+++ b/test/helpers/personnel_requests_helper_test.rb
@@ -18,15 +18,16 @@ class PersonnelRequestsHelperTest < ActionView::TestCase
   def test_currency_formats
     fields = %w( nonop_funds  annual_cost  annual_base_pay  hourly_rate  )
    
-    # this abstracts out the AM class being used
-    thingy = OpenStruct.new
-    thingy.define_singleton_method(:call_field) { |field| self.send(field) } 
+    # this abstracts out the ActiveModel class being used
+    proxy = OpenStruct.new
+    proxy.define_singleton_method(:call_field) { |field| self.send(field) } 
     
     fields.each do |m|
       val = rand(10000) 
-      thingy.send("#{m}=".intern, val) 
-      assert_equal  number_to_currency( val ), call_record_field( thingy , m )
+      proxy.send("#{m}=".intern, val) 
+      assert_equal  number_to_currency( val ), call_record_field( proxy , m )
     end
+  
   end
 
 end

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -68,8 +68,8 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), ContractorRequest).count + 1,
-                     wb.sheet('ContractorRequest').last_row
-        assert_equal ContractorRequest.fields.length + 1, wb.sheet('ContractorRequest').last_column
+                     wb.sheet('ContractorRequests').last_row
+        assert_equal 12, wb.sheet('ContractorRequests').last_column
       ensure
         file.close
         file.unlink
@@ -94,8 +94,8 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal ContractorRequest.all.count + 1,
-                     wb.sheet('ContractorRequest').last_row
-        assert_equal ContractorRequest.fields.length + 1, wb.sheet('ContractorRequest').last_column
+                     wb.sheet('ContractorRequests').last_row
+        assert_equal 12, wb.sheet('ContractorRequests').last_column
       ensure
         file.close
         file.unlink

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -4,6 +4,12 @@ require 'integration/personnel_requests_test_helper'
 # Integration test for the ContractorRequest index page
 class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
   include PersonnelRequestsTestHelper
+  
+  def setup
+    @columns = %w(position_description employee_type_code request_type_code
+                 contractor_name number_of_months annual_base_pay nonop_funds
+                 division_code department_code unit_code review_status_name)  
+  end
 
   test 'currency field values show with two decimal places' do
     get contractor_requests_path
@@ -15,17 +21,14 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index including pagination and sorting' do
-    columns = %w(position_description employee_type_code request_type_code
-                 contractor_name number_of_months annual_base_pay nonop_funds
-                 division_code department_code unit_code review_status_name)
 
     get contractor_requests_path
     assert_template 'contractor_requests/index'
 
     # Verify sort links
-    assert_select 'a.sort_link', count: columns.size
+    assert_select 'a.sort_link', count: @columns.size
 
-    columns.each do |sort_column|
+    @columns.each do |sort_column|
       %w(asc desc).each do |sort_direction|
         q_param = { s: sort_column + ' ' + sort_direction }
         get contractor_requests_path, q: q_param
@@ -67,9 +70,12 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
+        # the spreadsheet's rows should equal the number of records +1 for the header 
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), ContractorRequest).count + 1,
                      wb.sheet('ContractorRequests').last_row
-        assert_equal 12, wb.sheet('ContractorRequests').last_column
+        # the spreadsheets coulumns should equal the number of fields + 1 for
+        # the record type 
+        assert_equal @columns.length + 1, wb.sheet('ContractorRequests').last_column
       ensure
         file.close
         file.unlink
@@ -93,9 +99,12 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
+        # the spreadsheet's rows should equal the number of records +1 for the header 
         assert_equal ContractorRequest.all.count + 1,
                      wb.sheet('ContractorRequests').last_row
-        assert_equal 12, wb.sheet('ContractorRequests').last_column
+        # the spreadsheets coulumns should equal the number of fields + 1 for
+        # the record type 
+        assert_equal @columns.length + 1, wb.sheet('ContractorRequests').last_column
       ensure
         file.close
         file.unlink

--- a/test/integration/contractor_requests_index_test.rb
+++ b/test/integration/contractor_requests_index_test.rb
@@ -4,11 +4,11 @@ require 'integration/personnel_requests_test_helper'
 # Integration test for the ContractorRequest index page
 class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
   include PersonnelRequestsTestHelper
-  
+
   def setup
     @columns = %w(position_description employee_type_code request_type_code
-                 contractor_name number_of_months annual_base_pay nonop_funds
-                 division_code department_code unit_code review_status_name)  
+                  contractor_name number_of_months annual_base_pay nonop_funds
+                  division_code department_code unit_code review_status_name)
   end
 
   test 'currency field values show with two decimal places' do
@@ -21,7 +21,6 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index including pagination and sorting' do
-
     get contractor_requests_path
     assert_template 'contractor_requests/index'
 
@@ -70,11 +69,11 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
-        # the spreadsheet's rows should equal the number of records +1 for the header 
+        # the spreadsheet's rows should equal the number of records +1 for the header
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), ContractorRequest).count + 1,
                      wb.sheet('ContractorRequests').last_row
         # the spreadsheets coulumns should equal the number of fields + 1 for
-        # the record type 
+        # the record type
         assert_equal @columns.length + 1, wb.sheet('ContractorRequests').last_column
       ensure
         file.close
@@ -99,11 +98,11 @@ class ContractorRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
-        # the spreadsheet's rows should equal the number of records +1 for the header 
+        # the spreadsheet's rows should equal the number of records +1 for the header
         assert_equal ContractorRequest.all.count + 1,
                      wb.sheet('ContractorRequests').last_row
         # the spreadsheets coulumns should equal the number of fields + 1 for
-        # the record type 
+        # the record type
         assert_equal @columns.length + 1, wb.sheet('ContractorRequests').last_column
       ensure
         file.close

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -90,8 +90,8 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), LaborRequest).count + 1,
-                     wb.sheet('LaborRequest').last_row
-        assert_equal LaborRequest.fields.length + 1, wb.sheet('LaborRequest').last_column
+                     wb.sheet('LaborRequests').last_row
+        assert_equal 15, wb.sheet('LaborRequests').last_column
       ensure
         file.close
         file.unlink
@@ -116,8 +116,8 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal LaborRequest.all.count + 1,
-                     wb.sheet('LaborRequest').last_row
-        assert_equal LaborRequest.fields.length + 1, wb.sheet('LaborRequest').last_column
+                     wb.sheet('LaborRequests').last_row
+        assert_equal 15, wb.sheet('LaborRequests').last_column
       ensure
         file.close
         file.unlink

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -4,12 +4,12 @@ require 'integration/personnel_requests_test_helper'
 # Integration test for the LaborRequest index page
 class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
   include PersonnelRequestsTestHelper
-  
+
   def setup
     @columns = %w(position_description employee_type_code request_type_code
-                 contractor_name number_of_positions hourly_rate hours_per_week
-                 number_of_weeks annual_cost nonop_funds division_code
-                 department_code unit_code review_status_name)  
+                  contractor_name number_of_positions hourly_rate hours_per_week
+                  number_of_weeks annual_cost nonop_funds division_code
+                  department_code unit_code review_status_name)
   end
 
   test 'currency field values show with two decimal places' do
@@ -59,7 +59,7 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
     run_as_user(users(:johnny_two_roles)) do
       get labor_requests_path
       assert_template 'labor_requests/index'
-      columns = @columns.dup 
+      columns = @columns.dup
       (columns.length / 3).times do
         sort_columns = columns.sample(3)
         columns -= Array.wrap(sort_columns)
@@ -88,11 +88,11 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
-        # the spreadsheet's rows should equal the number of records +1 for the header  
+        # the spreadsheet's rows should equal the number of records +1 for the header
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), LaborRequest).count + 1,
                      wb.sheet('LaborRequests').last_row
         # the spreadsheets coulumns should equal the number of fields + 1 for
-        # the record type 
+        # the record type
         assert_equal @columns.length + 1, wb.sheet('LaborRequests').last_column
       ensure
         file.close
@@ -117,11 +117,11 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
-        # the spreadsheet's rows should equal the number of records +1 for the header  
+        # the spreadsheet's rows should equal the number of records +1 for the header
         assert_equal LaborRequest.all.count + 1,
                      wb.sheet('LaborRequests').last_row
         # the spreadsheets coulumns should equal the number of fields + 1 for
-        # the record type 
+        # the record type
         assert_equal @columns.length + 1, wb.sheet('LaborRequests').last_column
       ensure
         file.close

--- a/test/integration/labor_requests_index_test.rb
+++ b/test/integration/labor_requests_index_test.rb
@@ -4,6 +4,13 @@ require 'integration/personnel_requests_test_helper'
 # Integration test for the LaborRequest index page
 class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
   include PersonnelRequestsTestHelper
+  
+  def setup
+    @columns = %w(position_description employee_type_code request_type_code
+                 contractor_name number_of_positions hourly_rate hours_per_week
+                 number_of_weeks annual_cost nonop_funds division_code
+                 department_code unit_code review_status_name)  
+  end
 
   test 'currency field values show with two decimal places' do
     get labor_requests_path
@@ -15,18 +22,13 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index including pagination and sorting' do
-    columns = %w(position_description employee_type_code request_type_code
-                 contractor_name number_of_positions hourly_rate hours_per_week
-                 number_of_weeks annual_cost nonop_funds division_code
-                 department_code unit_code review_status_name)
-
     get labor_requests_path
     assert_template 'labor_requests/index'
 
     # Verify sort links
-    assert_select 'a.sort_link', count: columns.size
+    assert_select 'a.sort_link', count: @columns.size
 
-    columns.each do |sort_column|
+    @columns.each do |sort_column|
       %w(asc desc).each do |sort_direction|
         q_param = { s: sort_column + ' ' + sort_direction }
         get labor_requests_path, q: q_param
@@ -53,14 +55,11 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index including multisorting' do
-    columns = %w(position_description employee_type_code request_type_code
-                 contractor_name number_of_positions hourly_rate hours_per_week
-                 number_of_weeks nonop_funds division_code department_code
-                 unit_code review_status_name)
     sort_directions = %w( asc desc )
     run_as_user(users(:johnny_two_roles)) do
       get labor_requests_path
       assert_template 'labor_requests/index'
+      columns = @columns.dup 
       (columns.length / 3).times do
         sort_columns = columns.sample(3)
         columns -= Array.wrap(sort_columns)
@@ -89,9 +88,12 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
+        # the spreadsheet's rows should equal the number of records +1 for the header  
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), LaborRequest).count + 1,
                      wb.sheet('LaborRequests').last_row
-        assert_equal 15, wb.sheet('LaborRequests').last_column
+        # the spreadsheets coulumns should equal the number of fields + 1 for
+        # the record type 
+        assert_equal @columns.length + 1, wb.sheet('LaborRequests').last_column
       ensure
         file.close
         file.unlink
@@ -115,9 +117,12 @@ class LaborRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
+        # the spreadsheet's rows should equal the number of records +1 for the header  
         assert_equal LaborRequest.all.count + 1,
                      wb.sheet('LaborRequests').last_row
-        assert_equal 15, wb.sheet('LaborRequests').last_column
+        # the spreadsheets coulumns should equal the number of fields + 1 for
+        # the record type 
+        assert_equal @columns.length + 1, wb.sheet('LaborRequests').last_column
       ensure
         file.close
         file.unlink

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -7,8 +7,8 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
 
   def setup
     @columns = %w(position_description employee_type_code request_type_code
-                 annual_base_pay nonop_funds division_code department_code
-                 unit_code review_status_name)
+                  annual_base_pay nonop_funds division_code department_code
+                  unit_code review_status_name)
   end
 
   test 'currency field values show with two decimal places' do
@@ -21,7 +21,6 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
   end
 
   test 'index including pagination and sorting' do
-
     get staff_requests_path
     assert_template 'staff_requests/index'
 
@@ -70,11 +69,11 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
         assert_nothing_raised do
           wb = Roo::Excelx.new(file.path)
         end
-        # the spreadsheet's rows should equal the number of records +1 for the header  
+        # the spreadsheet's rows should equal the number of records +1 for the header
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), StaffRequest).count + 1,
                      wb.sheet('StaffRequests').last_row
         # the spreadsheets coulumns should equal the number of fields + 1 for
-        # the record type 
+        # the record type
         assert_equal @columns.length + 1, wb.sheet('StaffRequests').last_column
       ensure
         file.close

--- a/test/integration/staff_requests_index_test.rb
+++ b/test/integration/staff_requests_index_test.rb
@@ -68,8 +68,8 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal Pundit.policy_scope!(users(:johnny_two_roles), StaffRequest).count + 1,
-                     wb.sheet('StaffRequest').last_row
-        assert_equal StaffRequest.fields.length + 1, wb.sheet('StaffRequest').last_column
+                     wb.sheet('StaffRequests').last_row
+        assert_equal 10, wb.sheet('StaffRequests').last_column
       ensure
         file.close
         file.unlink
@@ -94,8 +94,8 @@ class StaffRequestsIndexTest < ActionDispatch::IntegrationTest
           wb = Roo::Excelx.new(file.path)
         end
         assert_equal StaffRequest.all.count + 1,
-                     wb.sheet('StaffRequest').last_row
-        assert_equal StaffRequest.fields.length + 1, wb.sheet('StaffRequest').last_column
+                     wb.sheet('StaffRequests').last_row
+        assert_equal 10, wb.sheet('StaffRequests').last_column
       ensure
         file.close
         file.unlink

--- a/test/models/requests_by_type_report_test.rb
+++ b/test/models/requests_by_type_report_test.rb
@@ -14,8 +14,4 @@ class RequestsByTypeReportTest < ActiveSupport::TestCase
     assert @report.query.respond_to? :each
     assert @report.class.query.respond_to? :each
   end
-
-  test 'should return its fields' do
-    assert @report.fields.is_a? Hash
-  end
 end


### PR DESCRIPTION
Removed the .fields and #fields and replaced the functionality to be in a view
helper.

https://issues.umd.edu/browse/LIBITD-510