### PR TITLE
LIBITD-528 Set column default for labor_requests # of positions and #…

### DIFF
--- a/app/views/contractor_requests/_form.html.erb
+++ b/app/views/contractor_requests/_form.html.erb
@@ -38,7 +38,7 @@
       <tr>
         <th><%= f.label :number_of_months %></th>
         <td>
-          <%= f.number_field :number_of_months, min: 1, value: 1 %>
+          <%= f.number_field :number_of_months, min: 1 %>
           <%= help_text_icon('help_text.number_of_months') %>
         </td>
       </tr>

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -37,7 +37,7 @@
       <tr>
         <th><%= f.label :number_of_positions %></th>
         <td>
-          <%= f.number_field :number_of_positions, min: 1, value: 1 %>
+          <%= f.number_field :number_of_positions, min: 1 %>
           <%= help_text_icon('help_text.number_of_positions') %>
         </td>
       </tr>
@@ -59,7 +59,7 @@
       <tr>
         <th><%= f.label :number_of_weeks %></th>
         <td>
-          <%= f.number_field :number_of_weeks, min: 1, value: 1 %>
+          <%= f.number_field :number_of_weeks, min: 1 %>
           <%= help_text_icon('help_text.number_of_weeks') %>
         </td>
 

--- a/db/migrate/20161011073834_change_labor_request_defaults.rb
+++ b/db/migrate/20161011073834_change_labor_request_defaults.rb
@@ -1,0 +1,10 @@
+class ChangeLaborRequestDefaults < ActiveRecord::Migration
+  def change
+  
+      change_column_default :labor_requests,  :number_of_weeks, 1
+      change_column_default :labor_requests,  :number_of_positions, 1
+  
+      change_column_default :contractor_requests,  :number_of_months, 1
+  
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,22 +11,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160927084415) do
+ActiveRecord::Schema.define(version: 20161011073834) do
 
   create_table "contractor_requests", force: :cascade do |t|
     t.integer  "employee_type_id"
     t.string   "position_description"
     t.integer  "request_type_id"
     t.string   "contractor_name"
-    t.integer  "number_of_months"
+    t.integer  "number_of_months",     default: 1
     t.decimal  "annual_base_pay"
     t.decimal  "nonop_funds"
     t.string   "nonop_source"
     t.integer  "department_id"
     t.integer  "unit_id"
     t.text     "justification"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.integer  "review_status_id"
     t.text     "review_comment"
   end
@@ -81,17 +81,17 @@ ActiveRecord::Schema.define(version: 20160927084415) do
     t.string   "position_description"
     t.integer  "request_type_id"
     t.string   "contractor_name"
-    t.integer  "number_of_positions"
+    t.integer  "number_of_positions",  default: 1
     t.decimal  "hourly_rate"
     t.decimal  "hours_per_week"
-    t.integer  "number_of_weeks"
+    t.integer  "number_of_weeks",      default: 1
     t.decimal  "nonop_funds"
     t.string   "nonop_source"
     t.integer  "department_id"
     t.integer  "unit_id"
     t.text     "justification"
-    t.datetime "created_at",           null: false
-    t.datetime "updated_at",           null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.integer  "review_status_id"
     t.text     "review_comment"
   end

--- a/test/fixtures/contractor_requests.yml
+++ b/test/fixtures/contractor_requests.yml
@@ -46,6 +46,21 @@ c2_with_unit:
   review_status: under_review
   review_comment: nil
 
+libitd_528:
+  employee_type: c2
+  position_description: LIBITD-528
+  request_type: new
+  contractor_name: nil
+  number_of_months: 6
+  annual_base_pay: 100_000.00
+  nonop_funds: nil
+  nonop_source: nil
+  department: ssdr
+  unit: nil
+  justification: Needed for testing
+  review_status: under_review
+  review_comment: nil
+
 # Sample data for pagination
 contractor_request_1:
   employee_type: cont_fac

--- a/test/fixtures/labor_requests.yml
+++ b/test/fixtures/labor_requests.yml
@@ -51,6 +51,22 @@ fac_hrly_with_unit:
   review_status: under_review
   review_comment: nil
   
+libitd_528:
+  employee_type: fac_hrly
+  position_description: LIBITD-528
+  request_type: new
+  contractor_name: nil
+  number_of_positions: 5
+  hourly_rate: 100.00
+  hours_per_week: 40.00
+  number_of_weeks: 30
+  nonop_funds: nil
+  nonop_source: nil
+  department: as
+  unit: stk
+  justification: Needed for testing
+  review_status: under_review
+  review_comment: nil
 
 # Sample data for pagination
 labor_request_1:

--- a/test/integration/contractor_requests_edit_test.rb
+++ b/test/integration/contractor_requests_edit_test.rb
@@ -124,4 +124,15 @@ class ContractorRequestsEditTest < ActionDispatch::IntegrationTest
     get edit_contractor_request_path(@contractor_request)
     assert_select 'i.help-text-icon'
   end
+
+  test 'verify that number_of_months displays properly' do
+    request = contractor_requests(:libitd_528)
+    expected_number_of_months = request.number_of_months
+
+    get edit_contractor_request_path(request)
+
+    doc = Nokogiri::HTML(response.body)
+    num_months = doc.xpath("//input[@id='contractor_request_number_of_months']/@value").to_s.to_i
+    assert_equal expected_number_of_months, num_months
+  end
 end

--- a/test/integration/contractor_requests_new_test.rb
+++ b/test/integration/contractor_requests_new_test.rb
@@ -1,0 +1,14 @@
+require 'test_helper'
+
+# Integration test for the ContractorRequest new page
+class ContractorRequestsNewTest < ActionDispatch::IntegrationTest
+  def setup
+  end
+
+  test 'number_of_months field should default to 1' do
+    get new_contractor_request_path
+    doc = Nokogiri::HTML(response.body)
+    num_months = doc.xpath("//input[@id='contractor_request_number_of_months']/@value").to_s.to_i
+    assert_equal 1, num_months
+  end
+end

--- a/test/integration/labor_requests_edit_test.rb
+++ b/test/integration/labor_requests_edit_test.rb
@@ -122,4 +122,18 @@ class LaborRequestsEditTest < ActionDispatch::IntegrationTest
     get edit_labor_request_path(@labor_request)
     assert_select 'i.help-text-icon'
   end
+
+  test 'verify that number_of_positions and number_of_weeks display properly' do
+    request = labor_requests(:libitd_528)
+    expected_number_of_positions = request.number_of_positions
+    expected_number_of_weeks = request.number_of_weeks
+
+    get edit_labor_request_path(request)
+
+    doc = Nokogiri::HTML(response.body)
+    num_positions = doc.xpath("//input[@id='labor_request_number_of_positions']/@value").to_s.to_i
+    assert_equal expected_number_of_positions, num_positions
+    num_weeks = doc.xpath("//input[@id='labor_request_number_of_weeks']/@value").to_s.to_i
+    assert_equal expected_number_of_weeks, num_weeks
+  end
 end

--- a/test/integration/labor_requests_new_test.rb
+++ b/test/integration/labor_requests_new_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+# Integration test for the ContractorRequest new page
+class LaborRequestsNewTest < ActionDispatch::IntegrationTest
+  def setup
+  end
+
+  test 'number_of_positions field should default to 1' do
+    get new_labor_request_path
+    doc = Nokogiri::HTML(response.body)
+    num_positions = doc.xpath("//input[@id='labor_request_number_of_positions']/@value").to_s.to_i
+    assert_equal 1, num_positions
+  end
+
+  test 'number_of_week field should default to 1' do
+    get new_labor_request_path
+    doc = Nokogiri::HTML(response.body)
+    num_weeks = doc.xpath("//input[@id='labor_request_number_of_weeks']/@value").to_s.to_i
+    assert_equal 1, num_weeks
+  end
+end

--- a/test/integration/labor_requests_new_test.rb
+++ b/test/integration/labor_requests_new_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-# Integration test for the ContractorRequest new page
+# Integration test for the LaborRequest new page
 class LaborRequestsNewTest < ActionDispatch::IntegrationTest
   def setup
   end


### PR DESCRIPTION
… of weeks and contractor_requests # of months to 1

Sets the column to default to 1 for labor_requests number_of_positions, number_of_weeks &
contractor_requests number_of_months to 1. Also remove setting the value = 1 in the form.