### PR TITLE
LIBITD-534. Fixed "Export" returning no records from second page.

### DIFF
--- a/app/controllers/personnel_request_controller.rb
+++ b/app/controllers/personnel_request_controller.rb
@@ -17,7 +17,7 @@ module PersonnelRequestController
     # Returns the per_page used in the pagniation. xlsx should have all
     # records, otherwise defaults to the WillPaginate global
     def per_page
-      params[:format] == 'xlsx' ? 2**10 : WillPaginate.per_page
+      WillPaginate.per_page
     end
 
     # Returns a send_data of the XLSX of a record set ( used in the request
@@ -49,6 +49,13 @@ module PersonnelRequestController
     #
     # params: indifferent hash that's just the controller params passed in
     def scope_records(params = {})
-      policy_scope(@q.result.page(params[:page]).per_page(per_page)) || []
+      if params[:format] == 'xlsx'
+        # xlsx format should not use pagination, and always return all records
+        # allowed by scope
+        policy_scope(@q.result)
+      else
+        # Other formats use pagination
+        policy_scope(@q.result.page(params[:page]).per_page(per_page)) || []
+      end
     end
 end

--- a/test/controllers/labor_requests_controller_test.rb
+++ b/test/controllers/labor_requests_controller_test.rb
@@ -147,4 +147,22 @@ class LaborRequestsControllerTest < ActionController::TestCase
 
     assert_redirected_to labor_requests_path
   end
+
+  test 'xlsx format should include all records, even from second page' do
+    get :index, page: '2', format: 'xlsx'
+
+    file = Tempfile.new(['test_temp', '.xlsx'])
+    begin
+      file.write response.body
+      file.close
+      spreadsheet = Roo::Excelx.new(file.path)
+      num_labor_requests = LaborRequest.count
+      expected_row_count = num_labor_requests + 1 # include header row in count
+      assert num_labor_requests > 1, 'There are no labor requests'
+      assert_equal expected_row_count, spreadsheet.last_row
+    ensure
+      file.delete
+    end
+    assert_response :success
+  end
 end


### PR DESCRIPTION
Fixed a bug where the Excel spreadsheet generated from the "Export"
button would not contain any records if selected from the second
page.

Modified "scope_records" method so that pagination would not be
used with the 'xlsx' format.

https://issues.umd.edu/browse/LIBITD-534