### PR TITLE
LIBITD-556. Made CAS Directory ID field readonly.

### DIFF
--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -5,7 +5,7 @@
     <tbody>
       <tr>
         <th><%= f.label :cas_directory_id %></th>
-        <td><%= f.text_field :cas_directory_id %></td>
+        <td><%= f.text_field :cas_directory_id, readonly: @user.id? %></td>
       </tr>
 
       <tr>


### PR DESCRIPTION
Field can only be filled in when creating a user. If the user already has an id field (i.e., it's primary key in the database) then set the cas_directory_id field to readonly.

https://issues.umd.edu/browse/LIBITD-556