### PR TITLE
LIBITD-552. Use delocalize gem for handling numbers.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,9 @@ gem 'faker', '~> 1.6'
 # Excel support
 gem 'axlsx_rails'
 
+# ActiveRecord support for localized numbers
+gem 'delocalize'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -77,6 +77,8 @@ GEM
     coffee-script-source (1.10.0)
     concurrent-ruby (1.0.1)
     debug_inspector (0.0.2)
+    delocalize (1.1.0)
+      rails (>= 2)
     docile (1.1.5)
     dotenv (2.1.1)
     dotenv-rails (2.1.1)
@@ -237,6 +239,7 @@ DEPENDENCIES
   axlsx_rails
   byebug
   coffee-rails (~> 4.1.0)
+  delocalize
   dotenv-rails (~> 2.1.1)
   faker (~> 1.6)
   github-markup
@@ -269,4 +272,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   1.11.2
+   1.13.3

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -133,10 +133,11 @@ class ContractorRequestsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def contractor_request_params
+      localized_fields = { annual_base_pay: :number, nonop_funds: :number }
       allowed = [:employee_type_id, :position_title, :request_type_id,
                  :contractor_name, :number_of_months, :annual_base_pay,
                  :nonop_funds, :nonop_source, :department_id, :unit_id,
                  :justification] + policy(@contractor_request || ContractorRequest.new).permitted_attributes
-      params.require(:contractor_request).permit(allowed)
+      params.require(:contractor_request).permit(allowed).delocalize(localized_fields)
     end
 end

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -128,10 +128,11 @@ class LaborRequestsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def labor_request_params
+      localized_fields = { hourly_rate: :number, nonop_funds: :number }
       allowed = [:employee_type_id, :position_title, :request_type_id,
                  :contractor_name, :number_of_positions, :hourly_rate, :hours_per_week,
                  :number_of_weeks, :nonop_funds, :nonop_source, :department_id,
                  :unit_id, :justification] + policy(@labor_request || LaborRequest.new).permitted_attributes
-      params.require(:labor_request).permit(allowed)
+      params.require(:labor_request).permit(allowed).delocalize(localized_fields)
     end
 end

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -136,9 +136,10 @@ class StaffRequestsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def staff_request_params
+      localized_fields = { annual_base_pay: :number, nonop_funds: :number }
       allowed = [:employee_type_id, :position_title, :request_type_id,
                  :annual_base_pay, :nonop_funds, :nonop_source, :department_id,
                  :unit_id, :justification] + policy(@staff_request || StaffRequest.new).permitted_attributes
-      params.require(:staff_request).permit(allowed)
+      params.require(:staff_request).permit(allowed).delocalize(localized_fields)
     end
 end

--- a/app/views/contractor_requests/_form.html.erb
+++ b/app/views/contractor_requests/_form.html.erb
@@ -45,14 +45,14 @@
       <tr>
         <th><%= f.label :annual_base_pay %></th>
         <td>
-          <%= f.text_field :annual_base_pay, step: 0.01, value: number_with_precision(f.object.annual_base_pay, precision: 2) %>
+          <%= f.text_field :annual_base_pay, step: 0.01, value: number_with_precision(f.object.annual_base_pay, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.annual_base_pay') %>
         </td>
       </tr>
       <tr>
         <th><%= f.label :nonop_funds %></th>
         <td>
-          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2) %>
+          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.nonop_funds') %>
         </td>
       </tr>

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -44,7 +44,7 @@
       <tr>
         <th><%= f.label :hourly_rate %></th>
         <td>
-          <%= f.text_field :hourly_rate, value: number_with_precision(f.object.hourly_rate, precision: 2) %>
+          <%= f.text_field :hourly_rate, value: number_with_precision(f.object.hourly_rate, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.hourly_rate') %>
         </td>
       </tr>
@@ -67,7 +67,7 @@
       <tr>
         <th><%= f.label :nonop_funds %></th>
         <td>
-          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2) %>
+          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.nonop_funds') %>
         </td>
       </tr>

--- a/app/views/staff_requests/_form.html.erb
+++ b/app/views/staff_requests/_form.html.erb
@@ -31,14 +31,14 @@
       <tr>
         <th><%= f.label :annual_base_pay %></th>
         <td>
-          <%= f.text_field :annual_base_pay, step: 0.01, value: number_with_precision(f.object.annual_base_pay, precision: 2) %>
+          <%= f.text_field :annual_base_pay, step: 0.01, value: number_with_precision(f.object.annual_base_pay, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.annual_base_pay') %>
         </td>
       </tr>
       <tr>
         <th><%= f.label :nonop_funds %></th>
         <td>
-          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2) %>
+          <%= f.text_field :nonop_funds, step: 0.01, value: number_with_precision(f.object.nonop_funds, precision: 2, delimiter: ',') %>
           <%= help_text_icon('help_text.nonop_funds') %>
         </td>
       </tr>


### PR DESCRIPTION
Convert the localized number formats with commas into non-localized numbers that ActiveRecord can handle. Previously, it was truncating at the comma since it was not a digit or a decimal point. Also forced the thousands delimiter to comma for the currency fields on the request forms.

https://issues.umd.edu/browse/LIBITD-552