### PR TITLE
LIBITD-623 Bind popover() to turbolinks:load

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -1,4 +1,7 @@
 // enable popovers for descriptors
-$(document).ready(function() {
+var togglr = function() { 
     $('[data-toggle="popover"]').popover()
-});
+}
+
+$(document).ready(togglr);
+$(document).on("turbolinks:load", togglr);


### PR DESCRIPTION
Turbolinks mucks about with the page loading so that document.ready is only fired when
the user visits the page the first time.
We should bind to document.ready and turbolinks:load events.

https://issues.umd.edu/browse/LIBITD-623