### PR TITLE
LIBITD-624 Add more help documents

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -1,6 +1,6 @@
 // enable popovers for descriptors
 var togglr = function() { 
-    $('[data-toggle="popover"]').popover()
+    $('[data-toggle="popover"]').popover({ html: true })
 }
 
 $(document).ready(togglr);

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -60,7 +60,7 @@
         <th><%= f.label :number_of_weeks, class: :required  %></th>
         <td>
           <%= f.number_field :number_of_weeks, min: 1 %>
-          <%= help_text_icon('help_text.number_of_weeks') %>
+          <%= help_text_icon('help_text.number_of_weeks_html') %>
         </td>
 
       </tr>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,6 @@
 <% provide :container_class, "container-fluid" %>
 <% content_for :navbar do %>
   <ul class="nav navbar-nav">
-    <li><%= link_to 'Help', "http://libi.lib.umd.edu/sites/default/files/FY18%20L&A%20Budget%20Calculations-Number%20of%20Weeks_0.pdf" %></li>
     <li class="<%= 'active' if current_page?(labor_requests_path) %>"><%= link_to 'Labor and Assistance', labor_requests_path %></li>
     <li class="<%= 'active' if current_page?(staff_requests_path) %>"><%= link_to 'Staff', staff_requests_path %></li>
     <li class="<%= 'active' if current_page?(contractor_requests_path) %>"><%= link_to 'Salaried Contractor', contractor_requests_path %></li>
@@ -50,6 +49,16 @@
         </ul>
       </li>
     <% end %>   
+    <li class='dropdown'>
+        <a href="#" class="dropdown-toggle" data-toggle="dropdown">
+          Help 
+          <span class="caret"></span>
+        </a>
+        <ul class="dropdown-menu">
+          <li><%= link_to 'Number Of Weeks Guide', "http://libi.lib.umd.edu/sites/default/files/FY18%20L&A%20Budget%20Calculations-Number%20of%20Weeks_0.pdf", target: "_blank" %></li>
+          <li><%= link_to 'FY18 Budget Calendar', "http://libi.lib.umd.edu/sites/default/files/Budget%20Calendar%20FY18.pdf", target: "_blank" %></li>
+        </ul>
+    </li> 
   </ul>
 <% end %>
 <% content_for :navbar_banner do %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -53,7 +53,7 @@ en:
     nonop_source: Name of the gift account or name of the source of funds supporting the request
     number_of_months: Length of Contract period in months
     number_of_positions: You may combine students on the same line provided they are at the same rate of pay and the same number of hours per week.
-    number_of_weeks: Estimated number of weeks the person will work during the fiscal year.  Refer to the Number of Weeks document for assistance.
+    number_of_weeks_html: Estimated number of weeks the person will work during the fiscal year. Refer to the <a taget="_blank" href='http://libi.lib.umd.edu/sites/default/files/FY18%20L&A%20Budget%20Calculations-Number%20of%20Weeks_0.pdf'>Number of Weeks Guide</a> under "Help" for assistance. 
     position_title: Position name/title
     unit: Select Unit name within a department, if applicable.
     labor_request_description: Hourly Staff (Contingent 1's), Students and hourly faculty


### PR DESCRIPTION
This adds more to help documents, moves it to the far right of the nav bar and makes
it a drop-down. Also includes link to document in descriptor of number of weeks

https://issues.umd.edu/browse/LIBITD-624