### PR TITLE
LIBITD-658. Made "Justification" field required in personnel requests 

### DIFF
--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -30,6 +30,12 @@ textarea[id$='review_comment']
   width: 96%; // Leave space for "tooltip" icon
 }
 
+// Workaround until error styling is added to textarea in umd_lib_style
+// See LIBITD-659
+.field_with_errors textarea {
+  border: 2px solid #a94442;
+}
+
 // Help text icon - override icon colors and size
 .help-text-icon:after {
   background-color: transparent;

--- a/app/models/contractor_request.rb
+++ b/app/models/contractor_request.rb
@@ -14,6 +14,7 @@ class ContractorRequest < ActiveRecord::Base
   validates :contractor_name, presence: true, if: :contractor_name_required?
   validates :number_of_months, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :annual_base_pay, presence: true
+  validates :justification, presence: true
   validates_with RequestDepartmentValidator
 
   # Provides a short human-readable description for this record, for GUI prompts

--- a/app/models/labor_request.rb
+++ b/app/models/labor_request.rb
@@ -16,6 +16,7 @@ class LaborRequest < ActiveRecord::Base
   validates :hourly_rate, presence: true, numericality: { greater_than: 0.00 }
   validates :hours_per_week, presence: true, numericality: { greater_than: 0.00 }
   validates :number_of_weeks, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :justification, presence: true
 
   # Provides a short human-readable description for this record, for GUI prompts
   alias_attribute :description, :position_title

--- a/app/models/staff_request.rb
+++ b/app/models/staff_request.rb
@@ -13,6 +13,7 @@ class StaffRequest < ActiveRecord::Base
 
   validates :annual_base_pay, presence: true
   validates :employee_name, presence: true, if: :employee_name_required?
+  validates :justification, presence: true
 
   # Provides a short human-readable description for this record, for GUI prompts
   alias_attribute :description, :position_title

--- a/app/views/contractor_requests/_form.html.erb
+++ b/app/views/contractor_requests/_form.html.erb
@@ -86,7 +86,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= f.label :justification %></th>
+        <th><%= f.label :justification , class: :required %></th>
         <td>
           <%= f.text_area :justification %>
           <%= help_text_icon('help_text.justification') %>

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -101,7 +101,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= f.label :justification %></th>
+        <th><%= f.label :justification , class: :required %></th>
         <td>
           <%= f.text_area :justification %>
           <%= help_text_icon('help_text.justification') %>

--- a/app/views/staff_requests/_form.html.erb
+++ b/app/views/staff_requests/_form.html.erb
@@ -79,7 +79,7 @@
         </td>
       </tr>
       <tr>
-        <th><%= f.label :justification %></th>
+        <th><%= f.label :justification , class: :required %></th>
         <td>
           <%= f.text_area :justification %>
           <%= help_text_icon('help_text.justification') %>

--- a/test/models/contractor_request_test.rb
+++ b/test/models/contractor_request_test.rb
@@ -89,4 +89,9 @@ class ContractorRequestTest < ActiveSupport::TestCase
     @contractor_request.unit_id = invalid_unit.id
     assert_not @contractor_request.valid?
   end
+
+  test 'justification should be present' do
+    @contractor_request.justification = nil
+    assert_not @contractor_request.valid?
+  end
 end

--- a/test/models/labor_request_test.rb
+++ b/test/models/labor_request_test.rb
@@ -129,4 +129,9 @@ class LaborRequestTest < ActiveSupport::TestCase
     expected_value = @labor_request.number_of_positions * @labor_request.hourly_rate * @labor_request.hours_per_week * @labor_request.number_of_weeks
     assert_equal expected_value, @labor_request.annual_cost
   end
+
+  test 'justification should be present' do
+    @labor_request.justification = nil
+    assert_not @labor_request.valid?
+  end
 end

--- a/test/models/staff_request_test.rb
+++ b/test/models/staff_request_test.rb
@@ -26,15 +26,15 @@ class StaffRequestTest < ActiveSupport::TestCase
   end
 
   test 'should allow valid request types' do
-    # lets do all cept payadj which also requires a employee_name 
+    # lets do all cept payadj which also requires a employee_name
     StaffRequest::VALID_REQUEST_TYPE_CODES.each do |code|
-      next if code == "PayAdj" 
+      next if code == "PayAdj"
       @staff_request.request_type_id = RequestType.find_by_code(code).id
       assert @staff_request.valid?, "'#{code}' was not accepted as a valid request type!"
     end
-   
+
     # now lets test payadj
-    code = "PayAdj" 
+    code = "PayAdj"
 #    @staff_request.request_type_id = RequestType.find_by_code(code).id
 #    @staff_request.employee_name = "David Simon"
 #    assert @staff_request.valid?, "Problem with payadj #{@staff_request.errors.inspect }"
@@ -76,6 +76,11 @@ class StaffRequestTest < ActiveSupport::TestCase
 
     invalid_unit = units(:two)
     @staff_request.unit_id = invalid_unit.id
+    assert_not @staff_request.valid?
+  end
+
+  test 'justification should be present' do
+    @staff_request.justification = nil
     assert_not @staff_request.valid?
   end
 end


### PR DESCRIPTION
Made "Justification" field required in personnel requests.

Added CSS to style "Justification" textarea with a red border, when
there is a validation error with the field. This is really just a
workaround, until LIBITD-659.

https://issues.umd.edu/browse/LIBITD-658