### PR TITLE
LIBITD-537. Expand Labor requests cost summary report to include Division summaries

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -84,6 +84,7 @@ end
 group :test do
   gem 'minitest-reporters', '~> 1.1.8'
   gem 'minitest-ci', '~> 3.0.3'
+  gem 'minitest-hooks', '~> 1.4.0'
 
   # Code analysis tools
   gem 'rubocop', '~> 0.39.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,6 +115,7 @@ GEM
     minitest (5.9.1)
     minitest-ci (3.0.3)
       minitest (~> 5.0, >= 5.0.6)
+    minitest-hooks (1.4.0)
     minitest-reporters (1.1.12)
       ansi
       builder
@@ -251,6 +252,7 @@ DEPENDENCIES
   jbuilder (~> 2.0)
   jquery-rails
   minitest-ci (~> 3.0.3)
+  minitest-hooks (~> 1.4.0)
   minitest-reporters (~> 1.1.8)
   pg (~> 0.18.4)
   pundit (~> 1.1)

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -92,8 +92,20 @@ class ReportsController < ApplicationController
       @report = Report.find(params[:id])
     end
 
-    def report_params
+    def report_params # rubocop:disable Metrics/MethodLength
       report_parameters_keys = params[:report][:parameters].try(:keys)
+      if report_parameters_keys
+        # The following modifies the report_parameters_keys map if any of the
+        # keys are actually an array of values (such as might come back from
+        # a bunch of checkboxes forming a group).
+        report_parameters_keys.map! do |key|
+          if params[:report][:parameters][key].is_a?(Array)
+            [key.to_sym => []]
+          else
+            key
+          end
+        end
+      end
       params.require(:report).permit(:name, :format, :user_id, :user_id,
                                      parameters: report_parameters_keys)
     end

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -25,7 +25,8 @@ class ReportJob < ActiveJob::Base
 
     output = ApplicationController.new
                                   .render_to_string(template: report_template, formats: report.format,
-                                                    locals: { klass: klass, record_set: record_set })
+                                                    locals: { klass: klass, record_set: record_set,
+                                                              created_at: report.created_at })
 
     report.update! status: 'completed', output: output
   end

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -15,19 +15,26 @@ class ReportJob < ActiveJob::Base
   end
 
   # Run the individual report
+  # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
   def run_report(report)
     report.update! status: 'running'
 
     klass = report.name.constantize
 
-    record_set = klass.new(report.parameters).query
-    report_template = klass.template
+    r = klass.new(report.parameters)
+    if r.parameters_valid?
+      record_set = r.query
+      report_template = klass.template
 
-    output = ApplicationController.new
-                                  .render_to_string(template: report_template, formats: report.format,
-                                                    locals: { klass: klass, record_set: record_set,
-                                                              created_at: report.created_at })
-
-    report.update! status: 'completed', output: output
+      output = ApplicationController.new
+                                    .render_to_string(template: report_template, formats: report.format,
+                                                      locals: { klass: klass, record_set: record_set,
+                                                                created_at: report.created_at })
+      report.update! status: 'completed', output: output
+    else
+      report.update_attributes status: 'error'
+      report.update_attributes status_message: r.error_message
+    end
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/MethodLength
 end

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -62,4 +62,18 @@ module Reportable
   def template
     self.class.template
   end
+
+  # @return [Boolean] true if the provided parameters are valid, false
+  # otherwise. This default implementation always returns true.
+  def parameters_valid?
+    true
+  end
+
+  # @return [String,nil] a human-readable error message, or nil.
+  #   Typically used in conjunction with the "parameters_valid?" method to
+  #   describe why the parameters are invalid. This default implementation
+  #   returns nil.
+  def error_message
+    nil
+  end
 end

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -50,7 +50,7 @@ class LaborRequestsCostSummaryReport
       hourly_faculty_key = [department_code, 'FHRLY']
       students_key = [department_code, 'STUD']
       other_support_key = [department_code, 'other_support']
-      value = { department: department_code,
+      value = { department: dept.name,
                 division: division_code,
                 c1: annual_cost_totals[c1_key],
                 hourly_faculty: annual_cost_totals[hourly_faculty_key],
@@ -59,7 +59,11 @@ class LaborRequestsCostSummaryReport
       summary_data << value
     end
 
+    divisions = Division.all
     current_fiscal_year = 'FY17'
-    { summary_data: summary_data, current_fiscal_year: current_fiscal_year }
+    previous_fiscal_year = 'FY16'
+    { summary_data: summary_data, divisions: divisions,
+      current_fiscal_year: current_fiscal_year,
+      previous_fiscal_year: previous_fiscal_year }
   end
 end

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -43,7 +43,7 @@ class LaborRequestsCostSummaryReport
     allowed_review_status_ids = parameters[:review_status_ids]
     allowed_review_statuses = allowed_review_status_ids.map { |id| ReviewStatus.find(id) }
 
-    LaborRequest.includes(:department, :division, :employee_type, :review_status).each do |request|
+    LaborRequest.includes(:department, :employee_type, :review_status).each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
       emp_type_code = request.employee_type.code
@@ -59,7 +59,7 @@ class LaborRequestsCostSummaryReport
     # Stores in an array (to preserve the department ordering), a "value" Hash
     # representing that department's row in the table.
     summary_data = []
-    Department.order(:code).each do |dept|
+    Department.includes(:division).order(:code).each do |dept|
       department_code = dept.code
       division_code = dept.division.code
       c1_key = [department_code, 'C1']

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -63,6 +63,8 @@ class LaborRequestsCostSummaryReport
       summary_data << value
     end
 
-    { summary_headers: summary_headers, summary_data: summary_data }
+    current_fiscal_year = 'FY17'
+    { summary_headers: summary_headers, summary_data: summary_data,
+      current_fiscal_year: current_fiscal_year }
   end
 end

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -23,48 +23,43 @@ class LaborRequestsCostSummaryReport
 
   # @return [Object] the data used by the template
   def query # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    summary_headers = {
-      division: 'Div Name',
-      c1: "C1's",
-      hourly_faculty: 'Hourly Faculty',
-      students: 'Students',
-      other_support: 'Other Support'
-    }
-
-    # Stores annual cost totals, keyed by [division_code, emp_type_code]
+    # Stores annual cost totals, keyed by [department_code, emp_type_code]
     annual_cost_totals = Hash.new(0)
 
     # Stores nonop_fund totals, keyed by division_code
     other_support_totals = Hash.new(0)
 
     LaborRequest.includes(:department, :division, :employee_type).each do |request|
-      division_code = request.division.code
       emp_type_code = request.employee_type.code
-      key = [division_code, emp_type_code]
+      department_code = request.department.code
+      key = [department_code, emp_type_code]
       annual_cost = request.annual_cost
       nonop_funds = request.nonop_funds
       annual_cost_totals[key] += annual_cost unless annual_cost.nil?
-      other_support_totals[division_code] += nonop_funds unless nonop_funds.nil?
+      other_support_key = [department_code, 'other_support']
+      other_support_totals[other_support_key] += nonop_funds unless nonop_funds.nil?
     end
 
-    # Stores in an array (to preserve the division ordering), a "value" Hash
-    # representing that division's row in the table.
+    # Stores in an array (to preserve the department ordering), a "value" Hash
+    # representing that department's row in the table.
     summary_data = []
-    Division.order(:code).each do |div|
-      division_code = div.code
-      c1_key = [division_code, 'C1']
-      hourly_faculty_key = [division_code, 'FAC-Hrly']
-      students_key = [division_code, 'Student']
-      value = { division: division_code,
+    Department.order(:code).each do |dept|
+      department_code = dept.code
+      division_code = dept.division.code
+      c1_key = [department_code, 'C1']
+      hourly_faculty_key = [department_code, 'FHRLY']
+      students_key = [department_code, 'STUD']
+      other_support_key = [department_code, 'other_support']
+      value = { department: department_code,
+                division: division_code,
                 c1: annual_cost_totals[c1_key],
                 hourly_faculty: annual_cost_totals[hourly_faculty_key],
                 students: annual_cost_totals[students_key],
-                other_support: other_support_totals[division_code] }
+                other_support: other_support_totals[other_support_key] }
       summary_data << value
     end
 
     current_fiscal_year = 'FY17'
-    { summary_headers: summary_headers, summary_data: summary_data,
-      current_fiscal_year: current_fiscal_year }
+    { summary_data: summary_data, current_fiscal_year: current_fiscal_year }
   end
 end

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -2,6 +2,9 @@ require 'reportable'
 # A summary report for the costs of Labor and Assistance requests
 class LaborRequestsCostSummaryReport
   include Reportable
+
+  attr_reader :error_message
+
   class << self
     # @return [String] human-readable description of the report, displayed in
     #   the GUI.
@@ -19,6 +22,14 @@ class LaborRequestsCostSummaryReport
     def template
       'shared/labor_requests_cost_summary'
     end
+  end
+
+  def parameters_valid?
+    valid = parameters && parameters.key?(:review_status_ids)
+    return true if valid
+
+    @error_message = 'At least one review status must be specified!'
+    false
   end
 
   # @return [Object] the data used by the template

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -23,7 +23,7 @@ class LaborRequestsCostSummaryReport
 
   # @return [Object] the data used by the template
   def query # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
-    headers = {
+    summary_headers = {
       division: 'Div Name',
       c1: "C1's",
       hourly_faculty: 'Hourly Faculty',
@@ -49,7 +49,7 @@ class LaborRequestsCostSummaryReport
 
     # Stores in an array (to preserve the division ordering), a "value" Hash
     # representing that division's row in the table.
-    data = []
+    summary_data = []
     Division.order(:code).each do |div|
       division_code = div.code
       c1_key = [division_code, 'C1']
@@ -60,9 +60,9 @@ class LaborRequestsCostSummaryReport
                 hourly_faculty: annual_cost_totals[hourly_faculty_key],
                 students: annual_cost_totals[students_key],
                 other_support: other_support_totals[division_code] }
-      data << value
+      summary_data << value
     end
 
-    [headers, data]
+    { summary_headers: summary_headers, summary_data: summary_data }
   end
 end

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -65,8 +65,8 @@ class LaborRequestsCostSummaryReport
     end
 
     divisions = Division.all
-    current_fiscal_year = 'FY17'
-    previous_fiscal_year = 'FY16'
+    current_fiscal_year = I18n.t(:current_fiscal_year)
+    previous_fiscal_year = I18n.t(:previous_fiscal_year)
 
     { summary_data: summary_data, divisions: divisions,
       current_fiscal_year: current_fiscal_year,

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -29,7 +29,12 @@ class LaborRequestsCostSummaryReport
     # Stores nonop_fund totals, keyed by division_code
     other_support_totals = Hash.new(0)
 
-    LaborRequest.includes(:department, :division, :employee_type).each do |request|
+    allowed_review_status_ids = parameters[:review_status_ids]
+    allowed_review_statuses = allowed_review_status_ids.map { |id| ReviewStatus.find(id) }
+
+    LaborRequest.includes(:department, :division, :employee_type, :review_status).each do |request|
+      review_status = request.review_status
+      next unless allowed_review_statuses.include?(review_status)
       emp_type_code = request.employee_type.code
       department_code = request.department.code
       key = [department_code, emp_type_code]
@@ -62,8 +67,10 @@ class LaborRequestsCostSummaryReport
     divisions = Division.all
     current_fiscal_year = 'FY17'
     previous_fiscal_year = 'FY16'
+
     { summary_data: summary_data, divisions: divisions,
       current_fiscal_year: current_fiscal_year,
-      previous_fiscal_year: previous_fiscal_year }
+      previous_fiscal_year: previous_fiscal_year,
+      allowed_review_statuses: allowed_review_statuses }
   end
 end

--- a/app/views/reports/_labor_requests_cost_summary_report_form.html.erb
+++ b/app/views/reports/_labor_requests_cost_summary_report_form.html.erb
@@ -1,0 +1,29 @@
+<%= form_for @report,  namespace: "#{subreport.class.to_s.underscore}_" do |f| %>
+  <%= render 'shared/form_errors', errors: @report.errors %>
+  <div class "panel-heading"><h3 class="panel-title"><%= report_name %> : <%= subreport.description %></h3></div> 
+  <table class="table table-striped">
+    <tbody>
+      <tr>
+        <th><%= f.label :format %></th>
+        <td><%= f.select :format, report_formats(subreport) %></td>
+      </tr>
+      <%= f.fields_for :parameters do |pf| %> 
+        <tr>
+          <th><%= pf.label 'Include Requests with Review Status' %></th>
+          <td>
+            <% ReviewStatus.all.each do |reviewStatus| %>
+              <%= pf.check_box(:review_status_ids, {multiple: true, checked: true}, reviewStatus.id, nil) %>
+              <%= pf.label(:review_status,  reviewStatus.name)  %>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>   
+    </tbody>
+  </table>
+
+  <%= f.hidden_field :user_id, value:  current_user.id %>
+  <%= f.hidden_field :name, value: subreport.class.to_s %>
+ 
+  <%= render partial: 'shared/form_action_buttons', locals: { form: f, object: @report } %>
+
+<% end %>

--- a/app/views/reports/show.html.erb
+++ b/app/views/reports/show.html.erb
@@ -21,17 +21,22 @@
     
     <tr>
       <th>Created At:</th>
-      <td id="name"><%= @report.created_at %></td>
+      <td id="created_at"><%= @report.created_at %></td>
     </tr>
     
     <tr>
       <th>Status:</th>
-      <td id="name"><%= @report.status %></td>
+      <td id="status">
+        <%= @report.status %>
+        <% if @report.status_message %>
+          <span id="status_message"> - <%= @report.status_message %></span>
+        <% end %>
+      </td>
     </tr>
     
     <tr>
       <th>Parameters:</th>
-      <td id="name"><%= @report.parameters %></td>
+      <td id="parameters"><%= @report.parameters %></td>
     </tr>
 
   </tbody>

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -1,11 +1,18 @@
+# @return [String] a "safe" cell name for uses with the Axlsx gem by removing 
+#    spaces and underscores from the given name. 
+def axls_safe_cell_name(name)
+  name.delete(' ').delete('_')
+end
+
 # Sets the name of the given row/col to the given name
 # Note: The name must be unique in the workbook, not just the worksheet.
 # Also, Excel cannot seem to handle names should not contain underscores ("_"),
 # spaces (" "), or dashes ("-").
 def name_cell_in_row(row, col, cell_name)
   cell_location = "#{row.worksheet.name}!#{row.cells[col].r_abs}"
-  row.worksheet.workbook.add_defined_name cell_location, name: cell_name
+  row.worksheet.workbook.add_defined_name cell_location, name: axls_safe_cell_name(cell_name)
 end
+
 
 # Style definitions
 def define_styles(wb)
@@ -41,7 +48,7 @@ end
 
 def construct_division_worksheet(wb, styles, record_set, division)
   # Division Worksheet Construction
-  wb.add_worksheet(name: division) do |sheet|
+  wb.add_worksheet(name: axls_safe_cell_name(division)) do |sheet|
     row_num = 1
     data = record_set[:summary_data]
     current_fiscal_year = record_set[:current_fiscal_year]
@@ -87,20 +94,18 @@ def construct_division_worksheet(wb, styles, record_set, division)
                   widths: :auto
     # Cell names must be unique in workbook. Can't use "_" to separate
     # words, because it turns the next letter into uppercase.
-    name_cell_in_row(row, 1, division.downcase + 'c1totals')
-    name_cell_in_row(row, 2, division.downcase + 'hourlyfacultytotals')
-    name_cell_in_row(row, 3, division.downcase + 'studentstotals')
-    name_cell_in_row(row, 4, division.downcase + 'totaltotals')
-    name_cell_in_row(row, 5, division.downcase + 'othersupporttotals')
+    name_cell_in_row(row, 1, division + 'c1totals')
+    name_cell_in_row(row, 2, division + 'hourlyfacultytotals')
+    name_cell_in_row(row, 3, division + 'studentstotals')
+    name_cell_in_row(row, 4, division + 'totaltotals')
+    name_cell_in_row(row, 5, division + 'othersupporttotals')
     row_num += 1
   end
 end
 
-
-
 def construct_summary_worksheet(wb, styles, record_set)
   # Summary Worksheet Construction
-  wb.insert_worksheet(0, name:'Summary L & A') do |sheet|
+  wb.insert_worksheet(0, name:'Summary_L_and_A') do |sheet|
     row_num = 1
     data = record_set[:summary_data]
     current_fiscal_year = record_set[:current_fiscal_year]
@@ -130,10 +135,10 @@ def construct_summary_worksheet(wb, styles, record_set)
     divisions.each do |div|
       div_code = div.code.downcase
       sheet.add_row [ div.name, 
-                      "=#{div_code + 'c1totals'}",
-                      "=#{div_code + 'hourlyfacultytotals'}",
-                      "=#{div_code + 'studentstotals'}",
-                      "=#{div_code + 'othersupporttotals'}",
+                      "=#{axls_safe_cell_name(div_code + 'c1totals')}",
+                      "=#{axls_safe_cell_name(div_code + 'hourlyfacultytotals')}",
+                      "=#{axls_safe_cell_name(div_code + 'studentstotals')}",
+                      "=#{axls_safe_cell_name(div_code + 'othersupporttotals')}",
                       "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}"],
                       style: [nil, styles['currency'], styles['currency'], styles['currency'], styles['currency'], styles['currency']],
                       widths: :auto
@@ -141,7 +146,7 @@ def construct_summary_worksheet(wb, styles, record_set)
     end
     data_end_row = row_num - 1
 
-    sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
+    row = sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
                     "=SUM(B#{data_start_row}:B#{data_end_row})",
                     "=SUM(C#{data_start_row}:C#{data_end_row})",
                     "=SUM(D#{data_start_row}:D#{data_end_row})",
@@ -154,6 +159,7 @@ def construct_summary_worksheet(wb, styles, record_set)
                           styles['summary_result_top_border'],
                           styles['summary_result']],
                   widths: :auto
+    name_cell_in_row(row, 5, 'summarynetfyrequest')
     row_num += 1
   end
 end

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -13,42 +13,6 @@ def name_cell_in_row(row, col, cell_name)
   row.worksheet.workbook.add_defined_name cell_location, name: cell_name
 end
 
-# Style definitions
-#
-# @param wb [Axlsx::Workbook] the workbook to add the styles to
-# @return [Hash] containing the pre-defined styles division [Division] the division to use
-def define_styles(wb)
-  # Define style components
-  title_font_size = 16
-  header_font_size = 14
-  summary_description_font_size = 14
-  summary_result_font_size = 12
-
-  title_font = { sz: title_font_size, b: true }
-  header_font = { sz: header_font_size, b: true }
-  summary_description_font = { sz: summary_description_font_size, b: true, i: true }
-  summary_result_font = { sz: summary_result_font_size, b: true }
-
-  currency_format = { format_code: '$#,##0.00' }
-
-  top_border = { border: { style: :thick, color: '000000', name: :top, edges: [:top] } }
-  bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } }
-
-  # Style definitions
-  styles = {}
-  styles['currency'] = wb.styles.add_style(currency_format)
-  styles['extra_title'] = wb.styles.add_style(title_font)
-  styles['title'] = wb.styles.add_style title_font.merge(bg_color: 'FFFF00')
-  styles['header'] = wb.styles.add_style header_font.merge(bg_color: 'D9D9D9').merge(alignment: { wrap_text: true })
-  styles['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: 'D9D9D9').merge(bottom_border).merge(alignment: { wrap_text: true })
-  styles['summary_description'] = wb.styles.add_style summary_description_font
-  styles['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: 'D9D9D9')
-  styles['summary_result_top_border'] =
-    wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: 'D9D9D9').merge(top_border)
-
-  styles
-end
-
 def add_parameter_description_row(sheet, record_set)
   # Add Parameter Description Row
   allowed_review_statuses = record_set[:allowed_review_statuses]
@@ -73,18 +37,18 @@ def construct_division_worksheet(wb, styles, record_set, division)
     previous_fiscal_year = record_set[:previous_fiscal_year]
 
     sheet.add_row [division, "Divisional Summary of L & A Requests - #{current_fiscal_year}"],
-                  style: [styles['title'], styles['extra_title']],
+                  style: [styles[:title], styles[:extra_title]],
                   widths: [:auto, :ignore]
     sheet.merge_cells "B#{row_num}:D#{row_num}"
     row_num += 1
 
     sheet.add_row ['', ''],
-                  style: [styles['title'], nil],
+                  style: [styles[:title], nil],
                   widths: [:auto, :ignore]
     row_num += 1
 
     sheet.add_row ['Dept Name', "C1's", 'Hourly Faculty', 'Students', 'Total', 'Grant, Gift, Other Support'],
-                  style: styles['header_bottom_border']
+                  style: styles[:header_bottom_border]
     row_num += 1
 
     data_start_row = row_num
@@ -97,11 +61,11 @@ def construct_division_worksheet(wb, styles, record_set, division)
                      "=SUM(B#{row_num}:D#{row_num})",
                      record[:other_support]],
                     style: [nil,
-                            styles['currency'],
-                            styles['currency'],
-                            styles['currency'],
-                            styles['summary_result'],
-                            styles['currency']],
+                            styles[:currency],
+                            styles[:currency],
+                            styles[:currency],
+                            styles[:summary_result],
+                            styles[:currency]],
                     widths: [:auto, :auto, :auto, :auto, 15, :auto]
       row_num += 1
     end
@@ -113,12 +77,12 @@ def construct_division_worksheet(wb, styles, record_set, division)
                          "=SUM(D#{data_start_row}:D#{data_end_row})",
                          "=SUM(E#{data_start_row}:E#{data_end_row})",
                          "=SUM(F#{data_start_row}:F#{data_end_row})"],
-                        style: [styles['summary_description'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result']],
+                        style: [styles[:summary_description],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result]],
                         widths: :auto
     # Cell names must be unique in workbook. Can't use "_" to separate
     # words, because it turns the next letter into uppercase.
@@ -136,12 +100,12 @@ def construct_division_worksheet(wb, styles, record_set, division)
     # Previous Fiscal Year Row
     row = sheet.add_row ["Less: Total L & A Approved for #{previous_fiscal_year}",
                          nil, nil, nil, "=SUM(B#{row_num}:D#{row_num})", nil],
-                        style: [styles['summary_description'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result']],
+                        style: [styles[:summary_description],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result]],
                         widths: :auto
     # Cell names must be unique in workbook. Can't use "_" to separate
     # words, because it turns the next letter into uppercase.
@@ -163,12 +127,12 @@ def construct_division_worksheet(wb, styles, record_set, division)
                    "=#{axls_safe_cell_name(division + 'StudentsTotals')} - #{axls_safe_cell_name(division + 'PrevFyStudentsTotals')}",
                    "=#{axls_safe_cell_name(division + 'TotalTotals')} - #{axls_safe_cell_name(division + 'PrevFyTotalTotals')}",
                    "=#{axls_safe_cell_name(division + 'OtherSupportTotals')} - #{axls_safe_cell_name(division + 'PrevFyOtherSupportTotals')}"],
-                  style: [styles['summary_description'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result']],
+                  style: [styles[:summary_description],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result]],
                   widths: :auto
     row_num += 1
 
@@ -196,25 +160,25 @@ def construct_summary_worksheet(wb, styles, record_set)
     previous_fiscal_year = record_set[:previous_fiscal_year]
 
     sheet.add_row ['Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}"],
-                  style: [styles['title'], styles['extra_title']],
+                  style: [styles[:title], styles[:extra_title]],
                   widths: [:auto, :ignore]
     sheet.merge_cells "B#{row_num}:D#{row_num}"
     row_num += 1
 
     sheet.add_row [nil, nil],
-                  style: [styles['title'], nil],
+                  style: [styles[:title], nil],
                   widths: [:auto, :ignore]
     row_num += 1
 
     sheet.add_row [nil, nil, nil, nil, 'Less:', nil, nil, nil],
-                  style: styles['header'],
+                  style: styles[:header],
                   widths: :auto
     row_num += 1
 
     sheet.add_row ['Div Name', "C1's", 'Hourly Faculty', 'Students',
                    'Other Support', "Net #{current_fiscal_year} Request",
                    "Net #{previous_fiscal_year} Request", 'Increase (Decrease)'],
-                  style: styles['header_bottom_border']
+                  style: styles[:header_bottom_border]
     row_num += 1
 
     data_start_row = row_num
@@ -230,13 +194,13 @@ def construct_summary_worksheet(wb, styles, record_set)
                      nil,
                      "=F#{row_num} - G#{row_num}"],
                     style: [nil,
-                            styles['currency'],
-                            styles['currency'],
-                            styles['currency'],
-                            styles['currency'],
-                            styles['summary_result'],
-                            styles['currency'],
-                            styles['currency']],
+                            styles[:currency],
+                            styles[:currency],
+                            styles[:currency],
+                            styles[:currency],
+                            styles[:summary_result],
+                            styles[:currency],
+                            styles[:currency]],
                     widths: :auto
       row_num += 1
     end
@@ -250,14 +214,14 @@ def construct_summary_worksheet(wb, styles, record_set)
                          "=SUM(F#{data_start_row}:F#{data_end_row})",
                          "=SUM(G#{data_start_row}:G#{data_end_row})",
                          "=SUM(H#{data_start_row}:H#{data_end_row})"],
-                        style: [styles['summary_description'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result_top_border'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result']],
+                        style: [styles[:summary_description],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result_top_border],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result]],
                         widths: :auto
     name_cell_in_row(row, 1, 'SummaryC1Totals')
     name_cell_in_row(row, 2, 'SummaryHourlyFacultyTotals')
@@ -273,12 +237,12 @@ def construct_summary_worksheet(wb, styles, record_set)
     # Previous Fiscal Year Row
     row = sheet.add_row ["Less: L & A Requested for #{previous_fiscal_year}",
                          nil, nil, nil, nil, nil],
-                        style: [styles['summary_description'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result'],
-                                styles['summary_result']],
+                        style: [styles[:summary_description],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result],
+                                styles[:summary_result]],
                         widths: :auto
     name_cell_in_row(row, 1, 'SummaryPrevFyC1Totals')
     name_cell_in_row(row, 2, 'SummaryPrevFyHourlyFacultyTotals')
@@ -298,12 +262,12 @@ def construct_summary_worksheet(wb, styles, record_set)
                    '=SummaryStudentsTotals - SummaryPrevFyStudentsTotals',
                    '=SummaryOtherSupportTotals - SummaryPrevFyOtherSupportTotals',
                    '=SummaryNetRequest - SummaryPrevFyNetRequest'],
-                  style: [styles['summary_description'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result'],
-                          styles['summary_result']],
+                  style: [styles[:summary_description],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result],
+                          styles[:summary_result]],
                   widths: :auto
     row_num += 1
 
@@ -318,7 +282,7 @@ def construct_summary_worksheet(wb, styles, record_set)
 end
 
 wb = xlsx_package.workbook
-styles = define_styles(wb)
+styles = wb.define_styles
 
 # Create worksheet for each division
 divisions = record_set[:divisions]

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -1,24 +1,89 @@
+# Style definitions
+def define_styles(wb)
+  # Define style components
+  title_font_size = 16
+  header_font_size = 14
+  summary_description_font_size = 14
+  summary_result_font_size = 12
+
+  title_font = { sz: title_font_size, b: true }
+  header_font = { sz: header_font_size, b: true }
+  summary_description_font = { sz: summary_description_font_size, b: true, i: true }
+  summary_result_font = { sz: summary_result_font_size, b: true }
+
+  currency_format = { format_code: "$#,##0.00" }
+
+  top_border = { border: { style: :thick, color: '000000', name: :top, edges: [:top] } };
+  bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } };
+
+  # Style definitions
+  style = Hash.new
+  style['currency'] = wb.styles.add_style(currency_format)
+  style['extra_title'] = wb.styles.add_style(title_font)
+  style['title'] = wb.styles.add_style title_font.merge({ bg_color: "FFFF00" })
+  style['header'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9")
+  style['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9").merge(bottom_border)
+  style['summary_description'] = wb.styles.add_style summary_description_font
+  style['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9")
+  style['summary_result_top_border'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9").merge(top_border)
+
+  return style
+end
+
+worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
+
 headers = record_set[0]
 data = record_set[1]
-
+current_fiscal_year = 'FY17'
 row_num = 1
 
 wb = xlsx_package.workbook
-currency = wb.styles.add_style format_code: '$#,##0.00'
 
+style = define_styles(wb)
+
+# Worksheet Construction
 wb.add_worksheet(name: 'Summary L & A') do |sheet|
-  header_row = [headers[:division], headers[:c1], headers[:hourly_faculty], headers[:students],
-                headers[:other_support], 'Net FY Request']
-  sheet.add_row header_row
-
+  sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
+                style: [style['title'], style['extra_title']],
+                widths: [:auto, :ignore]
+  sheet.merge_cells "B#{row_num}:D#{row_num}"
   row_num += 1
 
+  sheet.add_row ['', ''],
+                style: [style['title'], nil],
+                widths: [:auto, :ignore]
+  row_num += 1
+
+  sheet.add_row ['', '', '', '', 'Less:', ''],
+                style: style['header'],
+                widths: :auto
+  row_num += 1
+
+  sheet.add_row [ headers[:division], headers[:c1], headers[:hourly_faculty], headers[:students], headers[:other_support], 'Net FY Request' ],
+                style: style['header_bottom_border']
+  row_num += 1
+
+  data_start_row = row_num
   data.each do |record|
-    recored_row = [record[:division], record[:c1], record[:hourly_faculty], record[:students],
-                   record[:other_support], "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}"]
-    sheet.add_row recored_row,
-                  style: [nil, currency, currency, currency, currency, currency],
-                  widths: [:auto, :auto, :auto, :auto, :auto, :auto]
+    sheet.add_row [ record[:division], record[:c1], record[:hourly_faculty], record[:students], record[:other_support], "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}" ],
+                  style: [nil, style['currency'], style['currency'], style['currency'], style['currency'], style['currency']],
+                  widths: :auto
     row_num += 1
   end
+  data_end_row = row_num - 1
+
+  sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
+                  "=SUM(B#{data_start_row}:B#{data_end_row})",
+                  "=SUM(C#{data_start_row}:C#{data_end_row})",
+                  "=SUM(D#{data_start_row}:D#{data_end_row})",
+                  "=SUM(E#{data_start_row}:E#{data_end_row})",
+                  "=SUM(F#{data_start_row}:F#{data_end_row})"],
+                style: [style['summary_description'],
+                        style['summary_result_top_border'],
+                        style['summary_result_top_border'],
+                        style['summary_result_top_border'],
+                        style['summary_result_top_border'],
+                        style['summary_result']],
+                widths: :auto
+  row_num += 1
 end

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -32,17 +32,18 @@ end
 
 worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
 
-headers = record_set[0]
-data = record_set[1]
 current_fiscal_year = 'FY17'
-row_num = 1
 
 wb = xlsx_package.workbook
 
 style = define_styles(wb)
 
-# Worksheet Construction
+# Summary Worksheet Construction
 wb.add_worksheet(name: 'Summary L & A') do |sheet|
+  row_num = 1
+  headers = record_set[:summary_headers]
+  data = record_set[:summary_data]
+
   sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
                 style: [style['title'], style['extra_title']],
                 widths: [:auto, :ignore]

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -1,3 +1,12 @@
+# Sets the name of the given row/col to the given name
+# Note: The name must be unique in the workbook, not just the worksheet.
+# Also, Excel cannot seem to handle names should not contain underscores ("_"),
+# spaces (" "), or dashes ("-").
+def name_cell_in_row(row, col, cell_name)
+  cell_location = "#{row.worksheet.name}!#{row.cells[col].r_abs}"
+  row.worksheet.workbook.add_defined_name cell_location, name: cell_name
+end
+
 # Style definitions
 def define_styles(wb)
   # Define style components
@@ -17,53 +26,118 @@ def define_styles(wb)
   bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } };
 
   # Style definitions
-  style = Hash.new
-  style['currency'] = wb.styles.add_style(currency_format)
-  style['extra_title'] = wb.styles.add_style(title_font)
-  style['title'] = wb.styles.add_style title_font.merge({ bg_color: "FFFF00" })
-  style['header'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9")
-  style['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9").merge(bottom_border)
-  style['summary_description'] = wb.styles.add_style summary_description_font
-  style['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9")
-  style['summary_result_top_border'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9").merge(top_border)
+  styles = Hash.new
+  styles['currency'] = wb.styles.add_style(currency_format)
+  styles['extra_title'] = wb.styles.add_style(title_font)
+  styles['title'] = wb.styles.add_style title_font.merge({ bg_color: "FFFF00" })
+  styles['header'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9")
+  styles['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9").merge(bottom_border)
+  styles['summary_description'] = wb.styles.add_style summary_description_font
+  styles['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9")
+  styles['summary_result_top_border'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9").merge(top_border)
 
-  return style
+  return styles
 end
 
-def construct_summary_worksheet(wb, style, record_set)
-  # Summary Worksheet Construction
-  wb.add_worksheet(name: 'Summary L & A') do |sheet|
+def construct_division_worksheet(wb, styles, record_set, division)
+  # Division Worksheet Construction
+  wb.add_worksheet(name: division) do |sheet|
     row_num = 1
-    headers = record_set[:summary_headers]
     data = record_set[:summary_data]
     current_fiscal_year = record_set[:current_fiscal_year]
 
-    sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
-                  style: [style['title'], style['extra_title']],
+    sheet.add_row [ division, "Divisional Summary of L & A Requests - #{current_fiscal_year}" ],
+                  style: [styles['title'], styles['extra_title']],
                   widths: [:auto, :ignore]
     sheet.merge_cells "B#{row_num}:D#{row_num}"
     row_num += 1
 
     sheet.add_row ['', ''],
-                  style: [style['title'], nil],
+                  style: [styles['title'], nil],
                   widths: [:auto, :ignore]
     row_num += 1
 
-    sheet.add_row ['', '', '', '', 'Less:', ''],
-                  style: style['header'],
-                  widths: :auto
-    row_num += 1
-
-    sheet.add_row [ headers[:division], headers[:c1], headers[:hourly_faculty], headers[:students], headers[:other_support], 'Net FY Request' ],
-                  style: style['header_bottom_border']
+    sheet.add_row [ 'Dept Name', "C1's", 'Hourly Faculty', 'Students', 'Total', 'Grant, Gift, Other Support' ],
+                  style: styles['header_bottom_border']
     row_num += 1
 
     data_start_row = row_num
     data.each do |record|
-      sheet.add_row [ record[:division], record[:c1], record[:hourly_faculty], record[:students], record[:other_support], "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}" ],
-                    style: [nil, style['currency'], style['currency'], style['currency'], style['currency'], style['currency']],
-                    widths: :auto
-      row_num += 1
+      if ( record[:division] == division )
+        row = sheet.add_row [ record[:department], record[:c1], record[:hourly_faculty], record[:students], "=SUM(B#{row_num}:D#{row_num})", record[:other_support] ],
+                      style: [nil, styles['currency'], styles['currency'], styles['currency'], styles['currency'], styles['currency']],
+                      widths: :auto
+        row_num += 1
+      end
+    end
+    data_end_row = row_num - 1
+
+    row = sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
+                    "=SUM(B#{data_start_row}:B#{data_end_row})",
+                    "=SUM(C#{data_start_row}:C#{data_end_row})",
+                    "=SUM(D#{data_start_row}:D#{data_end_row})",
+                    "=SUM(E#{data_start_row}:E#{data_end_row})",
+                    "=SUM(F#{data_start_row}:F#{data_end_row})"],
+                  style: [styles['summary_description'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result']],
+                  widths: :auto
+    # Cell names must be unique in workbook. Can't use "_" to separate
+    # words, because it turns the next letter into uppercase.
+    name_cell_in_row(row, 1, division.downcase + 'c1totals')
+    name_cell_in_row(row, 2, division.downcase + 'hourlyfacultytotals')
+    name_cell_in_row(row, 3, division.downcase + 'studentstotals')
+    name_cell_in_row(row, 4, division.downcase + 'totaltotals')
+    name_cell_in_row(row, 5, division.downcase + 'othersupporttotals')
+    row_num += 1
+  end
+end
+
+
+
+def construct_summary_worksheet(wb, styles, record_set)
+  # Summary Worksheet Construction
+  wb.insert_worksheet(0, name:'Summary L & A') do |sheet|
+    row_num = 1
+    data = record_set[:summary_data]
+    current_fiscal_year = record_set[:current_fiscal_year]
+
+    sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
+                  style: [styles['title'], styles['extra_title']],
+                  widths: [:auto, :ignore]
+    sheet.merge_cells "B#{row_num}:D#{row_num}"
+    row_num += 1
+
+    sheet.add_row ['', ''],
+                  style: [styles['title'], nil],
+                  widths: [:auto, :ignore]
+    row_num += 1
+
+    sheet.add_row ['', '', '', '', 'Less:', ''],
+                  style: styles['header'],
+                  widths: :auto
+    row_num += 1
+
+    sheet.add_row [ 'Div Name', "C1's", 'Hourly Faculty', 'Students', 'Other Support', "Net #{current_fiscal_year} Request" ],
+                  style: styles['header_bottom_border']
+    row_num += 1
+
+    data_start_row = row_num
+    divisions = Division.all
+    divisions.each do |div|
+      div_code = div.code.downcase
+      sheet.add_row [ div.name, 
+                      "=#{div_code + 'c1totals'}",
+                      "=#{div_code + 'hourlyfacultytotals'}",
+                      "=#{div_code + 'studentstotals'}",
+                      "=#{div_code + 'othersupporttotals'}",
+                      "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}"],
+                      style: [nil, styles['currency'], styles['currency'], styles['currency'], styles['currency'], styles['currency']],
+                      widths: :auto
+        row_num += 1
     end
     data_end_row = row_num - 1
 
@@ -73,12 +147,12 @@ def construct_summary_worksheet(wb, style, record_set)
                     "=SUM(D#{data_start_row}:D#{data_end_row})",
                     "=SUM(E#{data_start_row}:E#{data_end_row})",
                     "=SUM(F#{data_start_row}:F#{data_end_row})"],
-                  style: [style['summary_description'],
-                          style['summary_result_top_border'],
-                          style['summary_result_top_border'],
-                          style['summary_result_top_border'],
-                          style['summary_result_top_border'],
-                          style['summary_result']],
+                  style: [styles['summary_description'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result_top_border'],
+                          styles['summary_result']],
                   widths: :auto
     row_num += 1
   end
@@ -88,6 +162,11 @@ worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
 
 wb = xlsx_package.workbook
 
-style = define_styles(wb)
+styles = define_styles(wb)
 
-construct_summary_worksheet(wb, style, record_set)
+divisions = Division.all
+divisions.each do |div|
+  construct_division_worksheet(wb, styles, record_set, div.code)
+end
+
+construct_summary_worksheet(wb, styles, record_set)

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -1,5 +1,5 @@
-# @return [String] a "safe" cell name for uses with the Axlsx gem by removing 
-#    spaces and underscores from the given name. 
+# @return [String] a "safe" cell name for uses with the Axlsx gem by removing
+#    spaces and underscores from the given name.
 def axls_safe_cell_name(name)
   name.delete(' ').delete('_')
 end
@@ -10,11 +10,13 @@ end
 # spaces (" "), or dashes ("-").
 def name_cell_in_row(row, col, cell_name)
   cell_location = "#{row.worksheet.name}!#{row.cells[col].r_abs}"
-  row.worksheet.workbook.add_defined_name cell_location, name: axls_safe_cell_name(cell_name)
+  row.worksheet.workbook.add_defined_name cell_location, name: cell_name
 end
 
-
 # Style definitions
+#
+# @param wb [Axlsx::Workbook] the workbook to add the styles to
+# @return [Hash] containing the pre-defined styles division [Division] the division to use
 def define_styles(wb)
   # Define style components
   title_font_size = 16
@@ -27,33 +29,41 @@ def define_styles(wb)
   summary_description_font = { sz: summary_description_font_size, b: true, i: true }
   summary_result_font = { sz: summary_result_font_size, b: true }
 
-  currency_format = { format_code: "$#,##0.00" }
+  currency_format = { format_code: '$#,##0.00' }
 
-  top_border = { border: { style: :thick, color: '000000', name: :top, edges: [:top] } };
-  bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } };
+  top_border = { border: { style: :thick, color: '000000', name: :top, edges: [:top] } }
+  bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } }
 
   # Style definitions
-  styles = Hash.new
+  styles = {}
   styles['currency'] = wb.styles.add_style(currency_format)
   styles['extra_title'] = wb.styles.add_style(title_font)
-  styles['title'] = wb.styles.add_style title_font.merge({ bg_color: "FFFF00" })
-  styles['header'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9")
-  styles['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: "D9D9D9").merge(bottom_border)
+  styles['title'] = wb.styles.add_style title_font.merge(bg_color: 'FFFF00')
+  styles['header'] = wb.styles.add_style header_font.merge(bg_color: 'D9D9D9').merge(alignment: { wrap_text: true })
+  styles['header_bottom_border'] = wb.styles.add_style header_font.merge(bg_color: 'D9D9D9').merge(bottom_border).merge(alignment: { wrap_text: true })
   styles['summary_description'] = wb.styles.add_style summary_description_font
-  styles['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9")
-  styles['summary_result_top_border'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: "D9D9D9").merge(top_border)
+  styles['summary_result'] = wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: 'D9D9D9')
+  styles['summary_result_top_border'] =
+    wb.styles.add_style summary_result_font.merge(currency_format).merge(bg_color: 'D9D9D9').merge(top_border)
 
-  return styles
+  styles
 end
 
+# Constructs a worksheet for a single division.
+#
+# @param wb [Axlsx::Workbook] the workbook to add the worksheet to
+# @param styles [Hash] the pre-defined styles
+# @param record_set [Hash] the data to use
+# @param division [Division] the division to use
 def construct_division_worksheet(wb, styles, record_set, division)
   # Division Worksheet Construction
   wb.add_worksheet(name: axls_safe_cell_name(division)) do |sheet|
-    row_num = 1
     data = record_set[:summary_data]
+    row_num = 1
     current_fiscal_year = record_set[:current_fiscal_year]
+    previous_fiscal_year = record_set[:previous_fiscal_year]
 
-    sheet.add_row [ division, "Divisional Summary of L & A Requests - #{current_fiscal_year}" ],
+    sheet.add_row [division, "Divisional Summary of L & A Requests - #{current_fiscal_year}"],
                   style: [styles['title'], styles['extra_title']],
                   widths: [:auto, :ignore]
     sheet.merge_cells "B#{row_num}:D#{row_num}"
@@ -64,115 +74,232 @@ def construct_division_worksheet(wb, styles, record_set, division)
                   widths: [:auto, :ignore]
     row_num += 1
 
-    sheet.add_row [ 'Dept Name', "C1's", 'Hourly Faculty', 'Students', 'Total', 'Grant, Gift, Other Support' ],
+    sheet.add_row ['Dept Name', "C1's", 'Hourly Faculty', 'Students', 'Total', 'Grant, Gift, Other Support'],
                   style: styles['header_bottom_border']
     row_num += 1
 
     data_start_row = row_num
     data.each do |record|
-      if ( record[:division] == division )
-        row = sheet.add_row [ record[:department], record[:c1], record[:hourly_faculty], record[:students], "=SUM(B#{row_num}:D#{row_num})", record[:other_support] ],
-                      style: [nil, styles['currency'], styles['currency'], styles['currency'], styles['currency'], styles['currency']],
-                      widths: :auto
-        row_num += 1
-      end
+      next unless record[:division] == division
+      sheet.add_row [record[:department],
+                     record[:c1],
+                     record[:hourly_faculty],
+                     record[:students],
+                     "=SUM(B#{row_num}:D#{row_num})",
+                     record[:other_support]],
+                    style: [nil,
+                            styles['currency'],
+                            styles['currency'],
+                            styles['currency'],
+                            styles['summary_result'],
+                            styles['currency']],
+                    widths: [:auto, :auto, :auto, :auto, 15, :auto]
+      row_num += 1
     end
     data_end_row = row_num - 1
 
-    row = sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
-                    "=SUM(B#{data_start_row}:B#{data_end_row})",
-                    "=SUM(C#{data_start_row}:C#{data_end_row})",
-                    "=SUM(D#{data_start_row}:D#{data_end_row})",
-                    "=SUM(E#{data_start_row}:E#{data_end_row})",
-                    "=SUM(F#{data_start_row}:F#{data_end_row})"],
-                  style: [styles['summary_description'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result']],
-                  widths: :auto
+    row = sheet.add_row ["Total L & A Requested for #{current_fiscal_year}",
+                         "=SUM(B#{data_start_row}:B#{data_end_row})",
+                         "=SUM(C#{data_start_row}:C#{data_end_row})",
+                         "=SUM(D#{data_start_row}:D#{data_end_row})",
+                         "=SUM(E#{data_start_row}:E#{data_end_row})",
+                         "=SUM(F#{data_start_row}:F#{data_end_row})"],
+                        style: [styles['summary_description'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result']],
+                        widths: :auto
     # Cell names must be unique in workbook. Can't use "_" to separate
     # words, because it turns the next letter into uppercase.
-    name_cell_in_row(row, 1, division + 'c1totals')
-    name_cell_in_row(row, 2, division + 'hourlyfacultytotals')
-    name_cell_in_row(row, 3, division + 'studentstotals')
-    name_cell_in_row(row, 4, division + 'totaltotals')
-    name_cell_in_row(row, 5, division + 'othersupporttotals')
+    name_cell_in_row(row, 1, axls_safe_cell_name(division + 'C1Totals'))
+    name_cell_in_row(row, 2, axls_safe_cell_name(division + 'HourlyFacultyTotals'))
+    name_cell_in_row(row, 3, axls_safe_cell_name(division + 'StudentsTotals'))
+    name_cell_in_row(row, 4, axls_safe_cell_name(division + 'TotalTotals'))
+    name_cell_in_row(row, 5, axls_safe_cell_name(division + 'OtherSupportTotals'))
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Previous Fiscal Year Row
+    row = sheet.add_row ["Less: Total L & A Approved for #{previous_fiscal_year}",
+                         nil, nil, nil, "=SUM(B#{row_num}:D#{row_num})", nil],
+                        style: [styles['summary_description'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result']],
+                        widths: :auto
+    # Cell names must be unique in workbook. Can't use "_" to separate
+    # words, because it turns the next letter into uppercase.
+    name_cell_in_row(row, 1, axls_safe_cell_name(division + 'PrevFyC1Totals'))
+    name_cell_in_row(row, 2, axls_safe_cell_name(division + 'PrevFyHourlyFacultyTotals'))
+    name_cell_in_row(row, 3, axls_safe_cell_name(division + 'PrevFyStudentsTotals'))
+    name_cell_in_row(row, 4, axls_safe_cell_name(division + 'PrevFyTotalTotals'))
+    name_cell_in_row(row, 5, axls_safe_cell_name(division + 'PrevFyOtherSupportTotals'))
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Increase/Decrease Row
+    sheet.add_row ['Increase (Decrease) in L & A',
+                   "=#{axls_safe_cell_name(division + 'C1Totals')} - #{axls_safe_cell_name(division + 'PrevFyC1Totals')}",
+                   "=#{axls_safe_cell_name(division + 'HourlyFacultyTotals')} - #{axls_safe_cell_name(division + 'PrevFyHourlyFacultyTotals')}",
+                   "=#{axls_safe_cell_name(division + 'StudentsTotals')} - #{axls_safe_cell_name(division + 'PrevFyStudentsTotals')}",
+                   "=#{axls_safe_cell_name(division + 'TotalTotals')} - #{axls_safe_cell_name(division + 'PrevFyTotalTotals')}",
+                   "=#{axls_safe_cell_name(division + 'OtherSupportTotals')} - #{axls_safe_cell_name(division + 'PrevFyOtherSupportTotals')}"],
+                  style: [styles['summary_description'],
+                          styles['summary_result'],
+                          styles['summary_result'],
+                          styles['summary_result'],
+                          styles['summary_result'],
+                          styles['summary_result']],
+                  widths: :auto
     row_num += 1
   end
 end
 
+# Constructs a summary worksheet, inserting it at the front of the workbook.
+#
+# @param wb [Axlsx::Workbook] the workbook to add the worksheet to
+# @param styles [Hash] the pre-defined styles
+# @param record_set [Hash] the data to use
+# @param division [Division] the division to use
 def construct_summary_worksheet(wb, styles, record_set)
   # Summary Worksheet Construction
-  wb.insert_worksheet(0, name:'Summary_L_and_A') do |sheet|
+  wb.insert_worksheet(0, name: 'Summary_L_and_A') do |sheet|
     row_num = 1
-    data = record_set[:summary_data]
     current_fiscal_year = record_set[:current_fiscal_year]
+    previous_fiscal_year = record_set[:previous_fiscal_year]
 
-    sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
+    sheet.add_row ['Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}"],
                   style: [styles['title'], styles['extra_title']],
                   widths: [:auto, :ignore]
     sheet.merge_cells "B#{row_num}:D#{row_num}"
     row_num += 1
 
-    sheet.add_row ['', ''],
+    sheet.add_row [nil, nil],
                   style: [styles['title'], nil],
                   widths: [:auto, :ignore]
     row_num += 1
 
-    sheet.add_row ['', '', '', '', 'Less:', ''],
+    sheet.add_row [nil, nil, nil, nil, 'Less:', nil, nil, nil],
                   style: styles['header'],
                   widths: :auto
     row_num += 1
 
-    sheet.add_row [ 'Div Name', "C1's", 'Hourly Faculty', 'Students', 'Other Support', "Net #{current_fiscal_year} Request" ],
+    sheet.add_row ['Div Name', "C1's", 'Hourly Faculty', 'Students',
+                   'Other Support', "Net #{current_fiscal_year} Request",
+                   "Net #{previous_fiscal_year} Request", 'Increase (Decrease)'],
                   style: styles['header_bottom_border']
     row_num += 1
 
     data_start_row = row_num
-    divisions = Division.all
+    divisions = record_set[:divisions]
     divisions.each do |div|
       div_code = div.code.downcase
-      sheet.add_row [ div.name, 
-                      "=#{axls_safe_cell_name(div_code + 'c1totals')}",
-                      "=#{axls_safe_cell_name(div_code + 'hourlyfacultytotals')}",
-                      "=#{axls_safe_cell_name(div_code + 'studentstotals')}",
-                      "=#{axls_safe_cell_name(div_code + 'othersupporttotals')}",
-                      "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}"],
-                      style: [nil, styles['currency'], styles['currency'], styles['currency'], styles['currency'], styles['currency']],
-                      widths: :auto
-        row_num += 1
+      sheet.add_row [div.code,
+                     "=#{axls_safe_cell_name(div_code + 'C1Totals')}",
+                     "=#{axls_safe_cell_name(div_code + 'HourlyFacultyTotals')}",
+                     "=#{axls_safe_cell_name(div_code + 'StudentsTotals')}",
+                     "=#{axls_safe_cell_name(div_code + 'OtherSupportTotals')}",
+                     "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}",
+                     nil,
+                     "=F#{row_num} - G#{row_num}"],
+                    style: [nil,
+                            styles['currency'],
+                            styles['currency'],
+                            styles['currency'],
+                            styles['currency'],
+                            styles['summary_result'],
+                            styles['currency'],
+                            styles['currency']],
+                    widths: :auto
+      row_num += 1
     end
     data_end_row = row_num - 1
 
-    row = sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
-                    "=SUM(B#{data_start_row}:B#{data_end_row})",
-                    "=SUM(C#{data_start_row}:C#{data_end_row})",
-                    "=SUM(D#{data_start_row}:D#{data_end_row})",
-                    "=SUM(E#{data_start_row}:E#{data_end_row})",
-                    "=SUM(F#{data_start_row}:F#{data_end_row})"],
+    row = sheet.add_row ["Total L & A Requested for #{current_fiscal_year}",
+                         "=SUM(B#{data_start_row}:B#{data_end_row})",
+                         "=SUM(C#{data_start_row}:C#{data_end_row})",
+                         "=SUM(D#{data_start_row}:D#{data_end_row})",
+                         "=SUM(E#{data_start_row}:E#{data_end_row})",
+                         "=SUM(F#{data_start_row}:F#{data_end_row})",
+                         "=SUM(G#{data_start_row}:G#{data_end_row})",
+                         "=SUM(H#{data_start_row}:H#{data_end_row})"],
+                        style: [styles['summary_description'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result_top_border'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result']],
+                        widths: :auto
+    name_cell_in_row(row, 1, 'SummaryC1Totals')
+    name_cell_in_row(row, 2, 'SummaryHourlyFacultyTotals')
+    name_cell_in_row(row, 3, 'SummaryStudentsTotals')
+    name_cell_in_row(row, 4, 'SummaryOtherSupportTotals')
+    name_cell_in_row(row, 5, 'SummaryNetRequest')
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Previous Fiscal Year Row
+    row = sheet.add_row ["Less: L & A Requested for #{previous_fiscal_year}",
+                         nil, nil, nil, nil, nil],
+                        style: [styles['summary_description'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result'],
+                                styles['summary_result']],
+                        widths: :auto
+    name_cell_in_row(row, 1, 'SummaryPrevFyC1Totals')
+    name_cell_in_row(row, 2, 'SummaryPrevFyHourlyFacultyTotals')
+    name_cell_in_row(row, 3, 'SummaryPrevFyStudentsTotals')
+    name_cell_in_row(row, 4, 'SummaryPrevFyOtherSupportTotals')
+    name_cell_in_row(row, 5, 'SummaryPrevFyNetRequest')
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Increase/Decrease Row
+    sheet.add_row ['Increase (Decrease) in L & A',
+                   '=SummaryC1Totals - SummaryPrevFyC1Totals',
+                   '=SummaryHourlyFacultyTotals - SummaryPrevFyHourlyFacultyTotals',
+                   '=SummaryStudentsTotals - SummaryPrevFyStudentsTotals',
+                   '=SummaryOtherSupportTotals - SummaryPrevFyOtherSupportTotals',
+                   '=SummaryNetRequest - SummaryPrevFyNetRequest'],
                   style: [styles['summary_description'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
-                          styles['summary_result_top_border'],
+                          styles['summary_result'],
+                          styles['summary_result'],
+                          styles['summary_result'],
+                          styles['summary_result'],
                           styles['summary_result']],
                   widths: :auto
-    name_cell_in_row(row, 5, 'summarynetfyrequest')
     row_num += 1
   end
 end
 
-worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
-
 wb = xlsx_package.workbook
-
 styles = define_styles(wb)
 
-divisions = Division.all
+# Create worksheet for each division
+divisions = record_set[:divisions]
 divisions.each do |div|
   construct_division_worksheet(wb, styles, record_set, div.code)
 end
 
+# Create summary worksheet
 construct_summary_worksheet(wb, styles, record_set)

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -30,61 +30,64 @@ def define_styles(wb)
   return style
 end
 
-worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
+def construct_summary_worksheet(wb, style, record_set)
+  # Summary Worksheet Construction
+  wb.add_worksheet(name: 'Summary L & A') do |sheet|
+    row_num = 1
+    headers = record_set[:summary_headers]
+    data = record_set[:summary_data]
+    current_fiscal_year = record_set[:current_fiscal_year]
 
-current_fiscal_year = 'FY17'
+    sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
+                  style: [style['title'], style['extra_title']],
+                  widths: [:auto, :ignore]
+    sheet.merge_cells "B#{row_num}:D#{row_num}"
+    row_num += 1
+
+    sheet.add_row ['', ''],
+                  style: [style['title'], nil],
+                  widths: [:auto, :ignore]
+    row_num += 1
+
+    sheet.add_row ['', '', '', '', 'Less:', ''],
+                  style: style['header'],
+                  widths: :auto
+    row_num += 1
+
+    sheet.add_row [ headers[:division], headers[:c1], headers[:hourly_faculty], headers[:students], headers[:other_support], 'Net FY Request' ],
+                  style: style['header_bottom_border']
+    row_num += 1
+
+    data_start_row = row_num
+    data.each do |record|
+      sheet.add_row [ record[:division], record[:c1], record[:hourly_faculty], record[:students], record[:other_support], "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}" ],
+                    style: [nil, style['currency'], style['currency'], style['currency'], style['currency'], style['currency']],
+                    widths: :auto
+      row_num += 1
+    end
+    data_end_row = row_num - 1
+
+    sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
+                    "=SUM(B#{data_start_row}:B#{data_end_row})",
+                    "=SUM(C#{data_start_row}:C#{data_end_row})",
+                    "=SUM(D#{data_start_row}:D#{data_end_row})",
+                    "=SUM(E#{data_start_row}:E#{data_end_row})",
+                    "=SUM(F#{data_start_row}:F#{data_end_row})"],
+                  style: [style['summary_description'],
+                          style['summary_result_top_border'],
+                          style['summary_result_top_border'],
+                          style['summary_result_top_border'],
+                          style['summary_result_top_border'],
+                          style['summary_result']],
+                  widths: :auto
+    row_num += 1
+  end
+end
+
+worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [ klass.to_s ]
 
 wb = xlsx_package.workbook
 
 style = define_styles(wb)
 
-# Summary Worksheet Construction
-wb.add_worksheet(name: 'Summary L & A') do |sheet|
-  row_num = 1
-  headers = record_set[:summary_headers]
-  data = record_set[:summary_data]
-
-  sheet.add_row [ 'Consolidated Libraries', "Summary of L & A Requests - #{current_fiscal_year}" ],
-                style: [style['title'], style['extra_title']],
-                widths: [:auto, :ignore]
-  sheet.merge_cells "B#{row_num}:D#{row_num}"
-  row_num += 1
-
-  sheet.add_row ['', ''],
-                style: [style['title'], nil],
-                widths: [:auto, :ignore]
-  row_num += 1
-
-  sheet.add_row ['', '', '', '', 'Less:', ''],
-                style: style['header'],
-                widths: :auto
-  row_num += 1
-
-  sheet.add_row [ headers[:division], headers[:c1], headers[:hourly_faculty], headers[:students], headers[:other_support], 'Net FY Request' ],
-                style: style['header_bottom_border']
-  row_num += 1
-
-  data_start_row = row_num
-  data.each do |record|
-    sheet.add_row [ record[:division], record[:c1], record[:hourly_faculty], record[:students], record[:other_support], "=SUM(B#{row_num}:D#{row_num}) - E#{row_num}" ],
-                  style: [nil, style['currency'], style['currency'], style['currency'], style['currency'], style['currency']],
-                  widths: :auto
-    row_num += 1
-  end
-  data_end_row = row_num - 1
-
-  sheet.add_row [ "Total L & A Requested for #{current_fiscal_year}",
-                  "=SUM(B#{data_start_row}:B#{data_end_row})",
-                  "=SUM(C#{data_start_row}:C#{data_end_row})",
-                  "=SUM(D#{data_start_row}:D#{data_end_row})",
-                  "=SUM(E#{data_start_row}:E#{data_end_row})",
-                  "=SUM(F#{data_start_row}:F#{data_end_row})"],
-                style: [style['summary_description'],
-                        style['summary_result_top_border'],
-                        style['summary_result_top_border'],
-                        style['summary_result_top_border'],
-                        style['summary_result_top_border'],
-                        style['summary_result']],
-                widths: :auto
-  row_num += 1
-end
+construct_summary_worksheet(wb, style, record_set)

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -49,6 +49,15 @@ def define_styles(wb)
   styles
 end
 
+def add_parameter_description_row(sheet, record_set)
+  # Add Parameter Description Row
+  allowed_review_statuses = record_set[:allowed_review_statuses]
+  allowed_review_statuses_desc = allowed_review_statuses.map { |r| r.name }.join(', ')
+  sheet.add_row ["Requests with #{allowed_review_statuses_desc} review status"],
+                 style: [],
+                 widths: [:ignore]
+end
+
 # Constructs a worksheet for a single division.
 #
 # @param wb [Axlsx::Workbook] the workbook to add the worksheet to
@@ -161,6 +170,14 @@ def construct_division_worksheet(wb, styles, record_set, division)
                           styles['summary_result'],
                           styles['summary_result']],
                   widths: :auto
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Add Parameter Description Row
+    add_parameter_description_row(sheet, record_set)
     row_num += 1
   end
 end
@@ -288,6 +305,14 @@ def construct_summary_worksheet(wb, styles, record_set)
                           styles['summary_result'],
                           styles['summary_result']],
                   widths: :auto
+    row_num += 1
+
+    # Blank Row
+    sheet.add_row
+    row_num += 1
+
+    # Add Parameter Description Row
+    add_parameter_description_row(sheet, record_set)
     row_num += 1
   end
 end

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -20,10 +20,10 @@ end
 def add_parameter_description_row(sheet, record_set)
   # Add Parameter Description Row
   allowed_review_statuses = record_set[:allowed_review_statuses]
-  allowed_review_statuses_desc = allowed_review_statuses.map { |r| r.name }.join(', ')
+  allowed_review_statuses_desc = allowed_review_statuses.map(&:name).join(', ')
   sheet.add_row ["Requests with #{allowed_review_statuses_desc} review status"],
-                 style: [],
-                 widths: [:ignore]
+                style: [],
+                widths: [:ignore]
 end
 
 # Adds a row indicating the creation date of the report
@@ -32,8 +32,8 @@ end
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
 def add_report_creation_date_row(sheet, created_at)
   sheet.add_row ["Report creation date: #{created_at}"],
-                 style: [],
-                 widths: [:ignore]
+                style: [],
+                widths: [:ignore]
 end
 
 # Constructs a worksheet for a single division.
@@ -43,6 +43,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 def construct_division_worksheet(wb, styles, record_set, division, created_at)
   # Division Worksheet Construction
   wb.add_worksheet(name: axls_safe_cell_name(division)) do |sheet|

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -21,7 +21,7 @@ def add_parameter_description_row(sheet, record_set)
   # Add Parameter Description Row
   allowed_review_statuses = record_set[:allowed_review_statuses]
   allowed_review_statuses_desc = allowed_review_statuses.map(&:name).join(', ')
-  sheet.add_row ["Requests with #{allowed_review_statuses_desc} review status"],
+  sheet.add_row ["Requests with Review Status: #{allowed_review_statuses_desc}"],
                 style: [],
                 widths: [:ignore]
 end

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -13,11 +13,25 @@ def name_cell_in_row(row, col, cell_name)
   row.worksheet.workbook.add_defined_name cell_location, name: cell_name
 end
 
+# Adds a row describing the parameters used to create the report
+#
+# @param wb [Axlsx::Workbook] the workbook to add the worksheet to
+# @param record_set [Hash] the data to use
 def add_parameter_description_row(sheet, record_set)
   # Add Parameter Description Row
   allowed_review_statuses = record_set[:allowed_review_statuses]
   allowed_review_statuses_desc = allowed_review_statuses.map { |r| r.name }.join(', ')
   sheet.add_row ["Requests with #{allowed_review_statuses_desc} review status"],
+                 style: [],
+                 widths: [:ignore]
+end
+
+# Adds a row indicating the creation date of the report
+#
+# @param sheet [Axlsx::Worksheet] the workbook to add the worksheet to
+# @param created_at [ActiveSupport::TimeWithZone] the report creation time
+def add_report_creation_date_row(sheet, created_at)
+  sheet.add_row ["Report creation date: #{created_at}"],
                  style: [],
                  widths: [:ignore]
 end
@@ -28,7 +42,8 @@ end
 # @param styles [Hash] the pre-defined styles
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
-def construct_division_worksheet(wb, styles, record_set, division)
+# @param created_at [ActiveSupport::TimeWithZone] the report creation time
+def construct_division_worksheet(wb, styles, record_set, division, created_at)
   # Division Worksheet Construction
   wb.add_worksheet(name: axls_safe_cell_name(division)) do |sheet|
     data = record_set[:summary_data]
@@ -143,6 +158,10 @@ def construct_division_worksheet(wb, styles, record_set, division)
     # Add Parameter Description Row
     add_parameter_description_row(sheet, record_set)
     row_num += 1
+
+    # Add Report creation time row
+    add_report_creation_date_row(sheet, created_at)
+    row_num += 1
   end
 end
 
@@ -152,7 +171,8 @@ end
 # @param styles [Hash] the pre-defined styles
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
-def construct_summary_worksheet(wb, styles, record_set)
+# @param created_at [ActiveSupport::TimeWithZone] the report creation time
+def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   wb.insert_worksheet(0, name: 'Summary_L_and_A') do |sheet|
     row_num = 1
@@ -278,6 +298,10 @@ def construct_summary_worksheet(wb, styles, record_set)
     # Add Parameter Description Row
     add_parameter_description_row(sheet, record_set)
     row_num += 1
+
+    # Add Report creation time row
+    add_report_creation_date_row(sheet, created_at)
+    row_num += 1
   end
 end
 
@@ -287,8 +311,8 @@ styles = wb.define_styles
 # Create worksheet for each division
 divisions = record_set[:divisions]
 divisions.each do |div|
-  construct_division_worksheet(wb, styles, record_set, div.code)
+  construct_division_worksheet(wb, styles, record_set, div.code, created_at)
 end
 
 # Create summary worksheet
-construct_summary_worksheet(wb, styles, record_set)
+construct_summary_worksheet(wb, styles, record_set, created_at)

--- a/config/initializers/axlsx_styles.rb
+++ b/config/initializers/axlsx_styles.rb
@@ -16,7 +16,7 @@ module Axlsx
       header_font = { sz: header_font_size, b: true }
       summary_description_font = { sz: summary_description_font_size, b: true, i: true }
       summary_result_font = { sz: summary_result_font_size, b: true }
-      currency_format = { format_code: '$#,##0.00' }
+      currency_format = { format_code: '$#,##0.00;($#,##0.00)' }
       top_border = { border: { style: :thick, color: '000000', name: :top, edges: [:top] } }
       bottom_border = { border: { style: :thick, color: '000000', name: :bottom, edges: [:bottom] } }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -62,4 +62,7 @@ en:
 
   confirm_delete_prompt:
     default: Are you sure?
-    with_description: "Are you sure you want to delete '%{description}'?" 
+    with_description: "Are you sure you want to delete '%{description}'?"
+    
+  current_fiscal_year: FY17
+  previous_fiscal_year: FY16

--- a/db/migrate/20170118160334_add_status_message_to_report.rb
+++ b/db/migrate/20170118160334_add_status_message_to_report.rb
@@ -1,0 +1,5 @@
+class AddStatusMessageToReport < ActiveRecord::Migration
+  def change
+    add_column :reports, :status_message, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161028185124) do
+ActiveRecord::Schema.define(version: 20170118160334) do
 
   create_table "contractor_requests", force: :cascade do |t|
     t.integer  "employee_type_id"
@@ -113,12 +113,13 @@ ActiveRecord::Schema.define(version: 20161028185124) do
   create_table "reports", force: :cascade do |t|
     t.binary   "output"
     t.text     "parameters"
-    t.integer  "format",     default: 0, null: false
-    t.integer  "status",     default: 0, null: false
-    t.string   "name",                   null: false
+    t.integer  "format",         default: 0, null: false
+    t.integer  "status",         default: 0, null: false
+    t.string   "name",                       null: false
     t.integer  "user_id"
-    t.datetime "created_at",             null: false
-    t.datetime "updated_at",             null: false
+    t.datetime "created_at",                 null: false
+    t.datetime "updated_at",                 null: false
+    t.string   "status_message"
   end
 
   add_index "reports", ["user_id"], name: "index_reports_on_user_id"

--- a/docs/Reports.md
+++ b/docs/Reports.md
@@ -78,6 +78,20 @@ class MyReport
     # requests in that department.
     [StaffRequest.where(department_id: parameters[:department_id]).find_each]
   end
+  
+  # @return [Boolean] true if the provided parameters are valid, false
+  # otherwise. This default implementation always returns true.
+  def parameters_valid?
+    true
+  end
+
+  # @return [String,nil] a human-readable error message, or nil.
+  #   Typically used in conjunction with the "parameters_valid?" method to
+  #   describe why the parameters are invalid. This default implementation
+  #   returns nil.
+  def error_message
+    nil
+  end
 end
 ```
 
@@ -132,3 +146,5 @@ For example, the above sample report uses a user-provided "department" parameter
 
 This will add something like: report[:parameters] = { department_id: 19 }
 to your Report object when saving in the Report#new action. See app/views/reports/_requests_by_department_report_form.html.erb for a similar example.
+
+If necessary, the "parameters_valid?" and "error_message" methods in the "Reportable" interface can be used by the report to verify that the user-provided parameters are valid. If the parameters are invalid, the "parameters_valid?" should return false, and the "error_message" method should return a String with a human-readable error message.

--- a/lib/tasks/reports/labor_requests_cost_summary_report_test.rake
+++ b/lib/tasks/reports/labor_requests_cost_summary_report_test.rake
@@ -1,0 +1,16 @@
+include ActionView::Helpers::NumberHelper
+
+namespace :reports do
+  desc 'Calculate values that should appear in the Labor Requests Cost Summary Report'
+  task labor_requests_cost_summary_report_test: [:calculate_summary_page] do
+  end
+
+  desc 'Calculates and displays values that should appear on the summary worksheet'
+  task calculate_summary_page: :environment do
+    puts 'Summary_L_and_A Worksheet'
+    total_annual_cost = LaborRequest.all.to_a.sum(&:annual_cost)
+    nonop_cost = LaborRequest.sum(:nonop_funds)
+    net_fy_request = total_annual_cost - nonop_cost
+    puts "\tSummaryNetRequest: #{number_to_currency(net_fy_request)}"
+  end
+end

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -36,7 +36,8 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
     divisions = Division.all
     assert (divisions.count > 0)
     divisions.each do |div|
-      div_code = div.code
+      # Sheet names should not have underscores or spaces
+      div_code = div.code.delete(' ').delete('_')
       assert spreadsheet.sheets.include?(div_code)
     end
   end

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -16,8 +16,15 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
     # Rails test fixtures are not available at the time that method is called.
     return @@spreadsheet if @@spreadsheet
 
+    # Set review status ids to include in the report
+    review_status_ids = ReviewStatus.all.map { |rs| rs.id }
+    
     report_user = users(:test_user)
-    report_params = { name: 'LaborRequestsCostSummaryReport', format: 'xlsx', user_id: report_user.id}
+    report_params = { name: 'LaborRequestsCostSummaryReport',
+                      format: 'xlsx',
+                      user_id: report_user.id,
+                      parameters: { review_status_ids: review_status_ids }
+                    }
     report = Report.new(report_params)
     ReportJob.perform_now report
     report_id = report.id

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -8,6 +8,8 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
   def before_all
     @@spreadsheet = nil
     @@temp_file = nil
+    @@creation_date = nil
+    @@report_params = nil
   end
 
   # @return [Roo::Spreadsheet] the spreadsheet to use for testing.
@@ -18,16 +20,17 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
 
     # Set review status ids to include in the report
     review_status_ids = ReviewStatus.all.map { |rs| rs.id }
-    
+
     report_user = users(:test_user)
-    report_params = { name: 'LaborRequestsCostSummaryReport',
+    @@report_params = { name: 'LaborRequestsCostSummaryReport',
                       format: 'xlsx',
                       user_id: report_user.id,
                       parameters: { review_status_ids: review_status_ids }
                     }
-    report = Report.new(report_params)
+    report = Report.new(@@report_params)
     ReportJob.perform_now report
     report_id = report.id
+    @@creation_date = report.created_at
 
     get report_download_url(id: report_id, format: 'xlsx')
     assert_response :success
@@ -49,9 +52,27 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'each worksheet should contain parameter information about the report' do
+    review_status_ids = @@report_params[:parameters][:review_status_ids]
+    review_status_description = review_status_ids.map { |id| ReviewStatus.find(id).name }.join(', ')
+
+    spreadsheet.each_with_pagename do |name, sheet|
+      parsed = sheet.parse
+      assert(parsed.any? { |e| e.to_s.include?(review_status_description) },
+        "Could not find parameter information on '#{name}' worksheet")
+    end
+  end
+
+  test 'each worksheet should indicate the report creation date' do
+    spreadsheet.each_with_pagename do |name, sheet|
+      parsed = sheet.parse
+      assert(parsed.any? { |e| e.to_s.include?("#{@@creation_date}") },
+        "Could not find creation date on '#{name}' worksheet")
+    end
+  end
+
   # Runs after all tests, and ensures that the temp file is deleted.
   def after_all
     @@temp_file.delete if @@temp_file
   end
-
 end

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -72,6 +72,26 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'generating report without parameters will display error message on report detail page' do
+    report_user = users(:test_user)
+    report_params = { name: 'LaborRequestsCostSummaryReport',
+                      format: 'xlsx',
+                      user_id: report_user.id,
+                      parameters: {}
+                    }
+    report = Report.new(report_params)
+    ReportJob.perform_now report
+    report_id = report.id
+
+    get report_download_url(id: report_id, format: 'xlsx')
+    assert_response :success
+    assert report.error?
+
+    # Retrieve the report detail page
+    get report_url(id: report_id)
+    assert_select 'span#status_message'
+  end
+
   # Runs after all tests, and ensures that the temp file is deleted.
   def after_all
     @@temp_file.delete if @@temp_file

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -23,24 +23,24 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
     review_status_ids = ReviewStatus.all.map(&:id)
 
     report_user = users(:test_user)
-    @report_params = { name: 'LaborRequestsCostSummaryReport',
-                      format: 'xlsx',
-                      user_id: report_user.id,
-                      parameters: { review_status_ids: review_status_ids }
-                    }
-    report = Report.new(@report_params)
+    @@report_params = { name: 'LaborRequestsCostSummaryReport',
+                        format: 'xlsx',
+                        user_id: report_user.id,
+                        parameters: { review_status_ids: review_status_ids }
+                      }
+    report = Report.new(@@report_params)
     ReportJob.perform_now report
     report_id = report.id
-    @creation_date = report.created_at
+    @@creation_date = report.created_at
 
     get report_download_url(id: report_id, format: 'xlsx')
     assert_response :success
 
-    @temp_file = Tempfile.new(['test_temp', '.xlsx'], encoding: 'ascii-8bit')
+    @@temp_file = Tempfile.new(['test_temp', '.xlsx'], encoding: 'ascii-8bit')
 
-    @temp_file.write response.body
-    @temp_file.close
-    @@spreadsheet = Roo::Excelx.new(@temp_file.path)
+    @@temp_file.write response.body
+    @@temp_file.close
+    @@spreadsheet = Roo::Excelx.new(@@temp_file.path)
   end
 
   test 'spreadsheet should have worksheet for each division' do
@@ -54,7 +54,7 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
   end
 
   test 'each worksheet should contain parameter information about the report' do
-    review_status_ids = @report_params[:parameters][:review_status_ids]
+    review_status_ids = @@report_params[:parameters][:review_status_ids]
     review_status_description = review_status_ids.map { |id| ReviewStatus.find(id).name }.join(', ')
 
     spreadsheet.each_with_pagename do |name, sheet|
@@ -67,13 +67,13 @@ class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
   test 'each worksheet should indicate the report creation date' do
     spreadsheet.each_with_pagename do |name, sheet|
       parsed = sheet.parse
-      assert(parsed.any? { |e| e.to_s.include?("#{@creation_date}") },
+      assert(parsed.any? { |e| e.to_s.include?("#{@@creation_date}") },
         "Could not find creation date on '#{name}' worksheet")
     end
   end
 
   # Runs after all tests, and ensures that the temp file is deleted.
   def after_all
-    @temp_file.delete if @temp_file
+    @@temp_file.delete if @@temp_file
   end
 end

--- a/test/integration/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/integration/reports/labor_requests_cost_summary_report_test.rb
@@ -1,0 +1,49 @@
+require 'test_helper'
+require 'minitest/hooks/test'
+
+# Integration test for various parts of the reports workflow
+class LaborRequestCostSummaryReportTest < ActionDispatch::IntegrationTest
+  include Minitest::Hooks
+
+  def before_all
+    @@spreadsheet = nil
+    @@temp_file = nil
+  end
+
+  # @return [Roo::Spreadsheet] the spreadsheet to use for testing.
+  def spreadsheet
+    # Note: This code cannot be moved into the "before_all" method, because
+    # Rails test fixtures are not available at the time that method is called.
+    return @@spreadsheet if @@spreadsheet
+
+    report_user = users(:test_user)
+    report_params = { name: 'LaborRequestsCostSummaryReport', format: 'xlsx', user_id: report_user.id}
+    report = Report.new(report_params)
+    ReportJob.perform_now report
+    report_id = report.id
+
+    get report_download_url(id: report_id, format: 'xlsx')
+    assert_response :success
+
+    @@temp_file = Tempfile.new(['test_temp', '.xlsx'], encoding: 'ascii-8bit')
+
+    @@temp_file.write response.body
+    @@temp_file.close
+    @@spreadsheet = Roo::Excelx.new(@@temp_file.path)
+  end
+
+  test 'spreadsheet should have worksheet for each division' do
+    divisions = Division.all
+    assert (divisions.count > 0)
+    divisions.each do |div|
+      div_code = div.code
+      assert spreadsheet.sheets.include?(div_code)
+    end
+  end
+
+  # Runs after all tests, and ensures that the temp file is deleted.
+  def after_all
+    @@temp_file.delete if @@temp_file
+  end
+
+end

--- a/test/models/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/labor_requests_cost_summary_report_test.rb
@@ -4,6 +4,10 @@ require 'test_helper'
 class LaborRequestsCostSummaryReportTest < ActiveSupport::TestCase
   def setup
     @report = LaborRequestsCostSummaryReport.new
+
+    # Set review status ids to include in the report
+    review_status_ids = ReviewStatus.all.map { |rs| rs.id }
+    @report.parameters = { review_status_ids: review_status_ids }
   end
 
   test 'should give a descriptions of itself' do

--- a/test/models/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/labor_requests_cost_summary_report_test.rb
@@ -10,15 +10,15 @@ class LaborRequestsCostSummaryReportTest < ActiveSupport::TestCase
     assert_not @report.class.description.empty?
   end
 
-  test 'should return an array containing a Hash and a Array of Hashes' do
+  test 'should return a Hash containing an Array and a String' do
     query_result = @report.query
-    headers = query_result[0]
-    data = query_result[1]
+    summary_data = query_result[:summary_data]
+    current_fiscal_year = query_result[:current_fiscal_year]
 
-    assert headers.is_a?(Hash)
-    assert data.is_a?(Array)
+    assert summary_data.is_a?(Array)
+    assert current_fiscal_year.is_a?(String)
 
-    # "data" should contain an entry for each division
-    assert data.count == Division.count
+    # "data" should contain an entry for each department
+    assert summary_data.count == Department.count
   end
 end


### PR DESCRIPTION
Modified "Labor requests cost summary" report with the following changes:

1) Added additional worksheets for each division
2) Added styling
3) Added "Review Status" input parameters, to enable user to choose the review statuses that should be represented in the report.
4) Added a simple framework for validating report paramaters, and displaying errors.

https://issues.umd.edu/browse/LIBITD-537