### PR TITLE
LIBITD-562. Added "Admin Use Only" panel to show/edit pages

### DIFF
--- a/app/views/contractor_requests/_form.html.erb
+++ b/app/views/contractor_requests/_form.html.erb
@@ -92,22 +92,11 @@
           <%= help_text_icon('help_text.justification') %>
         </td>
       </tr>
-      <tr>
-        <th><%= f.label :review_status %></th>
-        <td>
-          <%= select("contractor_request", "review_status_id", ReviewStatus.order("name").collect { |r| [ r.name, r.id ] }, { prompt: 'Select Review Status' }, disabled: !current_user.admin?) %>
-          <%= help_text_icon('help_text.review_status') %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :review_comment %></th>
-        <td>
-          <%= f.text_area :review_comment, :disabled => !current_user.admin? %>
-          <%= help_text_icon('help_text.review_comment') %>
-        </td>
-      </tr>
     </tbody>
   </table>
+
+  <%= render partial: 'shared/form_admin_use_only', 
+             locals: { form: f, personnel_request_type: "contractor_request" } %>
 
   <%= render partial: 'shared/form_action_buttons', locals: { form: f, object: @contractor_request } %>
 <% end %>

--- a/app/views/contractor_requests/show.html.erb
+++ b/app/views/contractor_requests/show.html.erb
@@ -59,16 +59,10 @@
         <th>Justification</th>
         <td id="justification"><%= @contractor_request.justification %></td>
       </tr>
-      <tr>
-        <th>Request Status:</th>
-        <td id="request_status"><%= @contractor_request.review_status.name if @contractor_request.review_status %></td>
-      </tr>
-      <tr>
-        <th>Review Comment:</th>
-        <td id="review_comment"><%= @contractor_request.review_comment %></td>
-      </tr>
     </tbody>
   </table>
+
+  <%= render 'shared/show_admin_use_only', object: @contractor_request %>
 
   <%= render 'shared/show_action_buttons', object: @contractor_request %>
 </div>

--- a/app/views/labor_requests/_form.html.erb
+++ b/app/views/labor_requests/_form.html.erb
@@ -107,22 +107,11 @@
           <%= help_text_icon('help_text.justification') %>
         </td>
       </tr>
-      <tr>
-        <th><%= f.label :review_status %></th>
-        <td>
-          <%= select("labor_request", "review_status_id", ReviewStatus.order("name").collect { |r| [ r.name, r.id ] }, { prompt: 'Select Review Status' }, disabled: !current_user.admin?) %>
-          <%= help_text_icon('help_text.review_status') %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :review_comment %></th>
-        <td>
-          <%= f.text_area :review_comment, :disabled => !current_user.admin? %>
-          <%= help_text_icon('help_text.review_comment') %>
-        </td>
-      </tr>
     </tbody>
   </table>
-    
+
+  <%= render partial: 'shared/form_admin_use_only', 
+             locals: { form: f, personnel_request_type: "labor_request" } %>
+
   <%= render partial: 'shared/form_action_buttons', locals: { form: f, object: @labor_request } %>
 <% end %>

--- a/app/views/labor_requests/show.html.erb
+++ b/app/views/labor_requests/show.html.erb
@@ -74,16 +74,10 @@
       <th>Justification:</th>
       <td id="justification"><%= @labor_request.justification %></td>
     </tr>
-    <tr>
-      <th>Request Status:</th>
-      <td id="request_status"><%= @labor_request.review_status.name if @labor_request.review_status %></td>
-    </tr>
-    <tr>
-      <th>Review Comment:</th>
-      <td id="review_comment"><%= @labor_request.review_comment %></td>
-    </tr>
   </tbody>
 </table>
+
+<%= render 'shared/show_admin_use_only', object: @labor_request %>
 
 <%= render 'shared/show_action_buttons', object: @labor_request %>
 </div>

--- a/app/views/shared/_form_admin_use_only.erb
+++ b/app/views/shared/_form_admin_use_only.erb
@@ -1,0 +1,28 @@
+<%#
+# Displays "Admin Use Only" section for personnel request "Edit" pages 
+%>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Admin Use Only</h3>
+  </div>
+  <div class="panel-body">
+  <table class="table table-striped">
+    <tbody>
+      <tr>
+        <th><%= form.label :review_status %></th>
+        <td>
+          <%= select(personnel_request_type, "review_status_id", ReviewStatus.order("name").collect { |r| [ r.name, r.id ] }, { prompt: 'Select Review Status' }, disabled: !current_user.admin?) %>
+          <%= help_text_icon('help_text.review_status') %>
+        </td>
+      </tr>
+      <tr>
+        <th><%= form.label :review_comment %></th>
+        <td>
+          <%= form.text_area :review_comment, :disabled => !current_user.admin? %>
+          <%= help_text_icon('help_text.review_comment') %>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+  </div>
+</div>

--- a/app/views/shared/_show_admin_use_only.erb
+++ b/app/views/shared/_show_admin_use_only.erb
@@ -1,0 +1,22 @@
+<%#
+# Displays "Admin Use Only" section for personnel request "Show" pages 
+%>
+<div class="panel panel-default">
+  <div class="panel-heading">
+    <h3 class="panel-title">Admin Use Only</h3>
+  </div>
+  <div class="panel-body">
+    <table class="table table-striped">
+      <tbody>
+        <tr>
+          <th>Request Status:</th>
+          <td id="request_status"><%= object.review_status.name if object.review_status %></td>
+        </tr>
+        <tr>
+          <th>Review Comment:</th>
+          <td id="review_comment"><%= object.review_comment %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>

--- a/app/views/staff_requests/_form.html.erb
+++ b/app/views/staff_requests/_form.html.erb
@@ -85,22 +85,11 @@
           <%= help_text_icon('help_text.justification') %>
         </td>
       </tr>
-      <tr>
-        <th><%= f.label :review_status %></th>
-        <td>
-          <%= select("staff_request", "review_status_id", ReviewStatus.order("name").collect { |r| [ r.name, r.id ] }, { prompt: 'Select Review Status' }, disabled: !current_user.admin?) %>
-          <%= help_text_icon('help_text.review_status') %>
-        </td>
-      </tr>
-      <tr>
-        <th><%= f.label :review_comment %></th>
-        <td>
-          <%= f.text_area :review_comment, :disabled => !current_user.admin? %>
-          <%= help_text_icon('help_text.review_comment') %>
-        </td>
-      </tr>
     </tbody>
   </table>
+
+  <%= render partial: 'shared/form_admin_use_only', 
+             locals: { form: f, personnel_request_type: "staff_request" } %>
     
   <%= render partial: 'shared/form_action_buttons', locals: { form: f, object: @staff_request } %>
 <% end %>

--- a/app/views/staff_requests/show.html.erb
+++ b/app/views/staff_requests/show.html.erb
@@ -49,16 +49,10 @@
       <th>Justification:</th>
       <td id="justification"><%= @staff_request.justification %></td>
     </tr>
-    <tr>
-      <th>Request Status:</th>
-      <td id="request_status"><%= @staff_request.review_status.name if @staff_request.review_status %></td>
-    </tr>
-    <tr>
-      <th>Review Comment:</th>
-      <td id="review_comment"><%= @staff_request.review_comment %></td>
-    </tr>
   </tbody>
 </table>
+  
+<%= render 'shared/show_admin_use_only', object: @staff_request %>
 
 <%= render 'shared/show_action_buttons', object: @staff_request %>
 </div>


### PR DESCRIPTION
Added an "Admin Use Only" panel that contains the "Review Status" and
"Review Comment" field.

Moved into a partial, and then updated all the show/edit personnel
request views.

https://issues.umd.edu/browse/LIBITD-562