### PR TITLE
LIBITD-731 Modify Division role type permision to read only the user'…

### DIFF
--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -143,12 +143,10 @@ class PersonnelRequestPolicy < ApplicationPolicy
     def resolve
       # Admin always sees everything
       # Users with Division role can see everything
-      return scope if user.admin? || user.division?
-
+      return scope if user.admin?
       return scope.none if user.roles.empty?
 
       scopes = allowed_departments(scope) + allowed_units(scope)
-
       # return the chained scopes
       scope.where(scopes.map { |s| s.arel.constraints.reduce(:and) }.reduce(:or))
     end

--- a/test/policies/personnel_request_policy_scope_test.rb
+++ b/test/policies/personnel_request_policy_scope_test.rb
@@ -36,10 +36,16 @@ class PersonnelRequestPolicyScopeTest < ActiveSupport::TestCase
   test 'division role can see all personnel requests' do
     expected_division_code = 'DSS'
     with_temp_user(divisions: [expected_division_code]) do |temp_user|
-      assert_equal LaborRequest.count, Pundit.policy_scope!(temp_user, LaborRequest).count
-      assert_equal StaffRequest.count, Pundit.policy_scope!(temp_user, StaffRequest).count
-      assert_equal ContractorRequest.all.count, Pundit.policy_scope!(temp_user, ContractorRequest).count
-    end
+      labor_results = Pundit.policy_scope!(temp_user, LaborRequest)
+      staff_results =   Pundit.policy_scope!(temp_user, StaffRequest)
+      contractor_results = Pundit.policy_scope!(temp_user, ContractorRequest)
+    
+      [labor_results, staff_results, contractor_results].each do |requests|
+        requests.each do |r|
+            assert_equal expected_division_code, r.division.code
+        end
+      end
+    end 
   end
 
   test 'department role can only see department personnel requests' do


### PR DESCRIPTION
…s division

instead of all divisions

This removes the access permissions that set users with division right == user's with admin.
Instead, division users can only access requests for dept/units within their
division.

https://issues.umd.edu/browse/LIBITD-731