### PR TITLE
LIBITD-779 Fixes Employee Type "Non-Exempt" code

### DIFF
--- a/app/models/reports/staff_requests_cost_summary_report.rb
+++ b/app/models/reports/staff_requests_cost_summary_report.rb
@@ -65,7 +65,7 @@ class StaffRequestsCostSummaryReport
       ex_key = [department_code, 'EX']
       fac_key = [department_code, 'FAC']
       ga_key = [department_code, 'GA']
-      nex_key = [department_code, 'Nex']
+      nex_key = [department_code, 'NEX']
       other_support_key = [department_code, 'other_support']
       value = { department: dept.name,
                 division: division_code,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -83,7 +83,7 @@ employee_types_by_category = {
   'Reg/GA' => [{ code: 'EX', name: 'Exempt' },
                { code: 'FAC', name: 'Faculty' },
                { code: 'GA', name: 'Graduate Assistant' },
-               { code: 'Nex', name: 'Non-exempt' }],
+               { code: 'NEX', name: 'Non-exempt' }],
   'SC' => [{ code: 'C2', name: 'Contractor Type 2' },
            { code: 'CFAC', name: 'ContFac' }] }
 

--- a/lib/tasks/upgrade/libitd779.rake
+++ b/lib/tasks/upgrade/libitd779.rake
@@ -1,0 +1,17 @@
+# lib/tasks/temporary/sample_data.rake
+namespace :upgrade do
+  desc 'Perform database upgrade tasks needed for LIBITD-779'
+  task libitd779: [:libitd779_upcase_employee_type] do
+  end
+
+  desc 'Upcase employee type codes'
+  task libitd779_upcase_employee_type: :environment do
+    ActiveRecord::Base.transaction do
+      EmployeeType.all.each do |et|
+          puts "Making #{et.code} into #{et.code.upcase}" 
+          et.code = et.code.upcase
+          et.save
+      end
+    end
+  end
+end

--- a/test/fixtures/employee_types.yml
+++ b/test/fixtures/employee_types.yml
@@ -46,8 +46,8 @@ ga:
   employee_category: reg_ga
 
 nex:
-  code: Nex
-  name: Nex
+  code: NEX
+  name: NEX
   employee_category: reg_ga
   
 student:

--- a/test/models/reports/staff_requests_cost_summary_report_test.rb
+++ b/test/models/reports/staff_requests_cost_summary_report_test.rb
@@ -16,6 +16,7 @@ class StaffRequestsCostSummaryReportTest < ActiveSupport::TestCase
 
   test 'should return a Hash containing various pieces of data' do
     query_result = @report.query
+    
     summary_data = query_result[:summary_data]
     divisions = query_result[:divisions]
     current_fiscal_year = query_result[:current_fiscal_year]
@@ -27,7 +28,9 @@ class StaffRequestsCostSummaryReportTest < ActiveSupport::TestCase
     assert_equal I18n.t(:current_fiscal_year),  current_fiscal_year
     assert_equal I18n.t(:previous_fiscal_year),  previous_fiscal_year
     assert_equal ReviewStatus.count, allowed_review_statuses.count
-    
+   
+
+    # NEX 
     # "data" should contain an entry for each department
     assert summary_data.count == Department.count
   end


### PR DESCRIPTION
The code for employee type "Non-exempt" seems to be either "Nex" or "NEX". This
sets the convention to be NEX ( app upcase ), which is similar to all the other
employee type codes.

https://issues.umd.edu/browse/LIBITD-779