### PR TITLE
LIBITD-749 Change migration and checking of model name

### DIFF
--- a/app/policies/personnel_request_policy.rb
+++ b/app/policies/personnel_request_policy.rb
@@ -286,10 +286,12 @@ class PersonnelRequestPolicy < ApplicationPolicy
     # @return [Boolean] returns if there is an archived model
     # works for both instances and classes
     def is_archived?
-      if record.respond_to? :class_name
-        record.class_name =~ /^Archived/
+      # an AR Class
+      if record.respond_to? :name
+        record.name =~ /^Archived/
+      # an AR instance
       else
-        record.class.class_name =~ /^Archived/
+        record.class.name =~ /^Archived/
       end
     end
 end

--- a/db/migrate/20170227175630_add_fiscal_rollover.rb
+++ b/db/migrate/20170227175630_add_fiscal_rollover.rb
@@ -2,12 +2,29 @@ class AddFiscalRollover < ActiveRecord::Migration
   def change
 
     %w( contractor_requests staff_requests labor_requests ).each do |table|
-      execute "CREATE TABLE archived_#{table} AS  SELECT * FROM #{table} WHERE 1=2"
-      add_column "archived_#{table}".intern, :fiscal_year, :string
+
+        create_table "archived_#{table}", force: :cascade do |t|
+          t.integer  "employee_type_id"
+          t.string   "position_title"
+          t.integer  "request_type_id"
+          t.string   "contractor_name"
+          t.integer  "number_of_months",      default: 1
+          t.decimal  "annual_base_pay_cents"
+          t.decimal  "nonop_funds"
+          t.string   "nonop_source"
+          t.integer  "department_id"
+          t.integer  "unit_id"
+          t.text     "justification"
+          t.datetime "created_at",                        null: false
+          t.datetime "updated_at",                        null: false
+          t.integer  "review_status_id"
+          t.text     "review_comment"
+          t.text     "fiscal_year" 
+        end
       
-      %i( employee_types review_statuses request_types divisions departments units  ).each do |m| 
-        add_column m, "archived_#{table}_count".intern, :integer
-      end
+        %i( employee_types review_statuses request_types divisions departments units  ).each do |m| 
+          add_column m, "archived_#{table}_count".intern, :integer
+        end
 
     end
     

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,14 +13,62 @@
 
 ActiveRecord::Schema.define(version: 20170227175630) do
 
-# Could not dump table "archived_contractor_requests" because of following NoMethodError
-#   undefined method `[]' for nil:NilClass
+  create_table "archived_contractor_requests", force: :cascade do |t|
+    t.integer  "employee_type_id"
+    t.string   "position_title"
+    t.integer  "request_type_id"
+    t.string   "contractor_name"
+    t.integer  "number_of_months",      default: 1
+    t.decimal  "annual_base_pay_cents"
+    t.decimal  "nonop_funds"
+    t.string   "nonop_source"
+    t.integer  "department_id"
+    t.integer  "unit_id"
+    t.text     "justification"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.integer  "review_status_id"
+    t.text     "review_comment"
+    t.text     "fiscal_year"
+  end
 
-# Could not dump table "archived_labor_requests" because of following NoMethodError
-#   undefined method `[]' for nil:NilClass
+  create_table "archived_labor_requests", force: :cascade do |t|
+    t.integer  "employee_type_id"
+    t.string   "position_title"
+    t.integer  "request_type_id"
+    t.string   "contractor_name"
+    t.integer  "number_of_months",      default: 1
+    t.decimal  "annual_base_pay_cents"
+    t.decimal  "nonop_funds"
+    t.string   "nonop_source"
+    t.integer  "department_id"
+    t.integer  "unit_id"
+    t.text     "justification"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.integer  "review_status_id"
+    t.text     "review_comment"
+    t.text     "fiscal_year"
+  end
 
-# Could not dump table "archived_staff_requests" because of following NoMethodError
-#   undefined method `[]' for nil:NilClass
+  create_table "archived_staff_requests", force: :cascade do |t|
+    t.integer  "employee_type_id"
+    t.string   "position_title"
+    t.integer  "request_type_id"
+    t.string   "contractor_name"
+    t.integer  "number_of_months",      default: 1
+    t.decimal  "annual_base_pay_cents"
+    t.decimal  "nonop_funds"
+    t.string   "nonop_source"
+    t.integer  "department_id"
+    t.integer  "unit_id"
+    t.text     "justification"
+    t.datetime "created_at",                        null: false
+    t.datetime "updated_at",                        null: false
+    t.integer  "review_status_id"
+    t.text     "review_comment"
+    t.text     "fiscal_year"
+  end
 
   create_table "contractor_requests", force: :cascade do |t|
     t.integer  "employee_type_id"


### PR DESCRIPTION
Changes the migration to explicitly build the archive table fields rather than
using SQL to copy the tables ( seems to be some problems depending on RDBMS )
Also changes the checking if the AR model is an "Archived" model. Minitest
seems to stub some class methods ( e.g.  .class_name ) that act rather
odd and seem platform dependant. Changes to use a different method.

https://issues.umd.edu/browse/LIBITD-749