### PR TITLE
LIBITD-925 Make more obvious what user and org permissions are

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -7,3 +7,17 @@ ul.version li { display: inline; margin: 0 5px; font-size: 10px; }
 
 ul.requests-homepage { list-style: none; }
 ul.requests-homepage a.list-group-item { font-weight: bold; }
+
+
+.org-info { 
+  border-style: solid;
+  border-width: 1px;
+  border-color: $impersonate_background;
+  .label { display: block; }
+
+ }
+
+.org-tree { 
+  .glyphicon-ok-circle { color: #008000; }
+  .glyphicon-ban-circle { color: #c91010; }
+ }

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -10,7 +10,10 @@ class Organization < ApplicationRecord
     def root_org
       root.first
     end
+  
   end
+    
+  TYPE_MAPPING = { "root" => 'queen', 'division' => 'bishop', 'department' => 'knight', 'unit' => 'pawn' }.freeze 
 
   belongs_to :parent, class_name: 'Organization', foreign_key: 'organization_id'
   validates :organization_id, presence: true, unless: :root?
@@ -27,6 +30,7 @@ class Organization < ApplicationRecord
   has_many :roles, dependent: :delete_all
   validates_associated :roles
   accepts_nested_attributes_for :roles, reject_if: :all_blank, allow_destroy: true
+  has_many :users, through: :roles
 
   validates :code, :organization_type, :name, presence: true
 
@@ -47,8 +51,10 @@ class Organization < ApplicationRecord
     Time.zone.today > organization_cutoff.cutoff_date
   end
 
+ 
+  # the name of the record used in the json expression
   def text
-    "#{name} (#{code})"
+    "#{name} (#{code}) <i class='glyphicon glyphicon-#{ cutoff? ? 'ban-circle' : 'ok-circle' }'></i>"
   end
 
   def grandchildren
@@ -59,15 +65,30 @@ class Organization < ApplicationRecord
     grandchildren.map(&:children).flatten || []
   end
 
+  # returns an array of the organizations up the tree
+  def ancestors
+    mom = parent
+    ancestors = []
+    while mom
+      ancestors << mom
+      mom = mom.parent
+    end
+    ancestors
+  end
+
   def description
     "#{name} ( #{organization_type} )"
   end
 
+  def type_icon
+    "glyphicon glyphicon-#{TYPE_MAPPING[organization_type]}"
+  end
+  
   def as_json(options = {})
     org = super
     org[:id] = org['id']
     org[:parent] = org['organization_id'] || '#'
-    org[:icon] = 'glyphicon glyphicon-home'
+    org[:icon] = type_icon
     org[:text] ||= text
     org[:state] = { opened: true }
     org

--- a/app/views/organizations/_form.erb
+++ b/app/views/organizations/_form.erb
@@ -63,6 +63,26 @@
           </div>
           
         <% end %>
+
+
+    <% @organization.ancestors.each do |ancestor| %>
+      <div class='panel panel-default'>
+        <div class="panel-heading"><span>Users with access from <%= link_to ancestor.description, ancestor %></span>
+        </div>
+          
+        <div class="panel-body" id="roles">
+          <ul>
+            <% ancestor.users.each do |u| %>
+              <li><%= link_to u.description, u %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    <% end %>
+
+
+
+
     </div>
   </div>
 </div>

--- a/app/views/organizations/edit.html.erb
+++ b/app/views/organizations/edit.html.erb
@@ -1,7 +1,5 @@
 <div class='container'>
   <div class="row">
-    <div class="col-md-8 col-md-offset-2">
       <%= render partial: 'form' %>
-    </div>
   </div>
 </div>

--- a/app/views/organizations/index.html.erb
+++ b/app/views/organizations/index.html.erb
@@ -1,12 +1,27 @@
 <%= render partial: 'organization_tree' %>
 <div class="page-header">                                                                                                                                                                                   
   <h1>Organizations
+    <span class='pull-right'>
     <span class='pull-right'><%= link_to( "New", new_organization_path, class: "btn btn-success" ) %></span>
   </h1>                                                                                                                                                                                        
 </div>                                                                                                                                                                                                      
-                                                                                                                                                                                                            
-<div class="btn-toolbar">
-</div>
 
-<div class='container' id="tree" >
+
+<div class='container org-tree'>
+  
+  <div class="col-md-3 pull-left org-info">
+    <h3><span class='label label-info'>Icons:</span></h3> 
+        <ul><% Organization::TYPE_MAPPING.each do |v, k| %>
+          <li><%= v %> = <i class='glyphicon glyphicon-<%= k %>'></i></li>
+        <% end %>
+        <li>active = <i class='glyphicon glyphicon-ok-circle'></i></li> 
+        <li>cutoff = <i class='glyphicon glyphicon-ban-circle'></i></li> 
+        </ul>
+        <h3><span class='label label-info'>Cutoff Dates:</span></h3> 
+        <ul><% OrganizationCutoff.all.each do |oc| %>
+          <li><%= oc.organization_type %> : <%= oc.cutoff_date %></li>
+        <% end %></ul>
+  </div>
+
+  <div class='col-md-9' id="tree" ></div>
 </div>

--- a/app/views/organizations/show.html.erb
+++ b/app/views/organizations/show.html.erb
@@ -1,7 +1,5 @@
 <div class='container readonly'>
   <div class="row">
-    <div class="col-md-8 col-md-offset-2">
-      <%= render partial: "form" %>
-    </div>
+    <%= render partial: "form" %>
   </div>
 </div>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -52,6 +52,29 @@
   
       <% end %>
 
+      <% if @user.all_organizations.length > 0 %>
+        <div class='panel panel-default'>
+          <div class="panel-heading">
+            <span>Current roles provide access to the following organizations:</span>
+          </div>
+          <div class="panel-body" id="roles">
+            <ul>
+              <% @user.all_organizations.each do |org| %>
+                <li>
+                  <%= link_to org.description, org %> 
+                  Cutoff Date: <%= org.organization_cutoff.cutoff_date %>
+                  <% if org.cutoff? %> 
+                    <span class='label label-danger pull-right'>INACTIVE</span>   
+                  <% else %> 
+                    <span class='label label-info pull-right'>ACTIVE</span>   
+                  <% end %> 
+                </li>
+              <% end %>
+            </ul>
+          </div>
+        </div>
+      <% end %>
+
     </div>
   </div>
 </div>


### PR DESCRIPTION
This tries to make it more clean in UI what the current roles are in
relation to orgs and users. User detail pages show what orgs are
included in the user's roles ( all orgs via the hierachy ).

The same is done for orgs, with org detail pages showing what users have
access to the org going up the ancestor chain.

The goal is to make it more clear what users have access to what orgs.

Also adds some UI elements to the org page to show what the status and
types are.