### PR TITLE
LIBITD-976 Ensure that the counter cache is reset after archiving

### DIFF
--- a/lib/counter_cache_manager.rb
+++ b/lib/counter_cache_manager.rb
@@ -7,7 +7,7 @@ class CounterCacheManager
     def run
       Rails.application.eager_load!
       logger ||= Logger.new(STDOUT)
-      logger.info("Resetting counter cache fields..")
+      logger.info("Resetting counter cache fields..") unless Rails.env === 'test'
       # get all reflections
       ActiveRecord::Base.descendants.each do |klass|
         next if klass == Organization # too much trouble...we'll brute force it later. 

--- a/lib/counter_cache_manager.rb
+++ b/lib/counter_cache_manager.rb
@@ -6,7 +6,8 @@ class CounterCacheManager
   class << self
     def run
       Rails.application.eager_load!
-
+      logger ||= Logger.new(STDOUT)
+      logger.info("Resetting counter cache fields..")
       # get all reflections
       ActiveRecord::Base.descendants.each do |klass|
         next if klass == Organization # too much trouble...we'll brute force it later. 
@@ -22,7 +23,6 @@ class CounterCacheManager
                 .group("#{one_table}.id", "#{many_table}_count")
                 .having("#{one_table}.#{many_table}_count != COUNT(#{many_table}.id)")
                 .pluck("#{one_table}.id")
-          # logger ||= Logger.new(STDOUT)
           # logger.info  "Resetting cache for #{one_klass} for #{klass} ( #{ids.length.to_s} #{many_table} records)"
           ids.each do |id|
             one_klass.reset_counters id, many_table

--- a/lib/tasks/archive_current_records.rake
+++ b/lib/tasks/archive_current_records.rake
@@ -14,3 +14,7 @@ namespace :db do
     end
   end
 end
+
+Rake::Task["db:archive_current_records"].enhance do
+  Rake::Task["db:migrate"].invoke
+end

--- a/lib/tasks/sample_data.rake
+++ b/lib/tasks/sample_data.rake
@@ -117,3 +117,7 @@ namespace :db do
   end
 
 end
+
+Rake::Task["db:populate_sample_data"].enhance do
+  Rake::Task["db:migrate"].invoke
+end


### PR DESCRIPTION
This ensures the counter cache is reset after records have been moved to
the archive. The reset task is run after the archive task.

https://issues.umd.edu/browse/LIBITD-976