### PR TITLE
LIBITD-977 Add an exporter to 1.2.0 for migration

### DIFF
--- a/lib/record_migrator.rb
+++ b/lib/record_migrator.rb
@@ -19,5 +19,3 @@ module TwoPointOhMigrator
   end
 
 end
-
-[ ContractorRequest, StaffRequest, LaborRequest ].each { |klass| klass.include(TwoPointOhMigrator) }

--- a/lib/record_migrator.rb
+++ b/lib/record_migrator.rb
@@ -1,0 +1,23 @@
+module TwoPointOhMigrator
+  
+  def to_v2
+    request = attributes
+    request["request_model_type"] = self.class.name.underscore.split("_").first
+    request["organization"]  = department.name
+    request.delete("department")
+    request["unit"] = unit.name if unit
+    attributes.keys.select { |attr| attr =~ /_id$/ }.each do |attr|
+      a = attr.remove(/_id$/)
+      if self.send(a)
+        request[a] = self.send(a.intern).name
+      else
+        request[a] = nil
+      end
+      request.delete(attr)
+    end
+    request
+  end
+
+end
+
+[ ContractorRequest, StaffRequest, LaborRequest ].each { |klass| klass.include(TwoPointOhMigrator) }

--- a/lib/tasks/dump_data.rake
+++ b/lib/tasks/dump_data.rake
@@ -5,6 +5,8 @@ namespace :db do
   desc "Dump pre-2.0 request data from the current enviroment's DB into JSON"
     task data_dump: :environment do
       Rails.application.eager_load!
+      [ ContractorRequest, StaffRequest, LaborRequest ]
+        .each { |klass| klass.include(TwoPointOhMigrator) }
        
       File.open(Rails.root.join("tmp/requests.json") , 'w') do |file|
         file << ActiveRecord::Base.subclasses
@@ -12,18 +14,5 @@ namespace :db do
           .map(&:all).map(&:to_a).flatten.map(&:to_v2).to_json
       end
     end
-
-  desc "Load request data from pre-2.0 JSON into the current database"
-    task data_load: :environment do
-      Rails.application.eager_load!
-       
-      File.open(Rails.root.join("tmp/requests.json") , 'w') do |file|
-        file << ActiveRecord::Base.subclasses
-          .select { |klass|  %w[ ContractorRequest LaborRequest StaffRequest ].include? klass.name }
-          .map(&:all).map(&:to_a).flatten.map(&:to_v2).to_json
-      end
-    end
-
-
 
 end

--- a/lib/tasks/dump_data.rake
+++ b/lib/tasks/dump_data.rake
@@ -1,0 +1,29 @@
+require_relative '../record_migrator'
+
+namespace :db do
+
+  desc "Dump pre-2.0 request data from the current enviroment's DB into JSON"
+    task data_dump: :environment do
+      Rails.application.eager_load!
+       
+      File.open(Rails.root.join("tmp/requests.json") , 'w') do |file|
+        file << ActiveRecord::Base.subclasses
+          .select { |klass|  %w[ ContractorRequest LaborRequest StaffRequest ].include? klass.name }
+          .map(&:all).map(&:to_a).flatten.map(&:to_v2).to_json
+      end
+    end
+
+  desc "Load request data from pre-2.0 JSON into the current database"
+    task data_load: :environment do
+      Rails.application.eager_load!
+       
+      File.open(Rails.root.join("tmp/requests.json") , 'w') do |file|
+        file << ActiveRecord::Base.subclasses
+          .select { |klass|  %w[ ContractorRequest LaborRequest StaffRequest ].include? klass.name }
+          .map(&:all).map(&:to_a).flatten.map(&:to_v2).to_json
+      end
+    end
+
+
+
+end


### PR DESCRIPTION
This adds a json exporter to dump records from 1.2.0 in preperation to
an update to 2.0

https://issues.umd.edu/browse/LIBITD-977