### PR TITLE
LIBITD-999. Fixed broken tests on feature/LIBITD-749 branch.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,11 +36,11 @@ gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '0.2.0'
 gem 'cocoon'
 gem 'simple_form'
 
-gem 'axlsx', '2.1.0.pre'
+gem 'axlsx', '2.0.1'
 gem 'axlsx_rails'
 gem 'fiscali'
 gem 'money-rails', '~>1'
-gem 'rubyzip', '~> 1.1.0'
+gem 'rubyzip'
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'
 
@@ -50,7 +50,7 @@ group :development, :test do
   gem 'byebug'
   gem 'faker'
   gem 'pry-rails'
-  gem 'roo'
+  gem 'roo', '1.13.2'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,10 +49,10 @@ GEM
     ansi (1.5.0)
     arel (6.0.4)
     ast (2.3.0)
-    axlsx (2.1.0.pre)
+    axlsx (2.0.1)
       htmlentities (~> 4.3.1)
       nokogiri (>= 1.4.1)
-      rubyzip (~> 1.1.7)
+      rubyzip (~> 1.0.0)
     axlsx_rails (0.5.1)
       actionpack (>= 3.1)
       axlsx (>= 2.0.1)
@@ -238,9 +238,10 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
-    roo (2.7.1)
-      nokogiri (~> 1)
-      rubyzip (~> 1.1, < 2.0.0)
+    roo (1.13.2)
+      nokogiri
+      rubyzip
+      spreadsheet (> 0.6.4)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -250,9 +251,10 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-checkstyle_formatter (0.4.0)
       rubocop (>= 0.35.1)
+    ruby-ole (1.2.12.1)
     ruby-progressbar (1.8.3)
     ruby_dep (1.3.1)
-    rubyzip (1.1.7)
+    rubyzip (1.0.0)
     sass (3.5.1)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -284,6 +286,8 @@ GEM
     simplecov-html (0.10.2)
     simplecov-rcov (0.2.3)
       simplecov (>= 0.4.1)
+    spreadsheet (1.1.4)
+      ruby-ole (>= 1.0)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.1)
@@ -328,7 +332,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  axlsx (= 2.1.0.pre)
+  axlsx (= 2.0.1)
   axlsx_rails
   bullet
   byebug
@@ -356,11 +360,11 @@ DEPENDENCIES
   rack_session_access
   rails (= 4.2.6)
   rb-fsevent
-  roo
+  roo (= 1.13.2)
   rubocop (= 0.49.1)
   rubocop-checkstyle_formatter
   ruby_dep (~> 1.3.1)
-  rubyzip (~> 1.1.0)
+  rubyzip
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   selenium-webdriver
@@ -381,4 +385,4 @@ DEPENDENCIES
   will_paginate-bootstrap
 
 BUNDLED WITH
-   1.15.1
+   1.15.3

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,6 +27,8 @@ module AnnualStaffingRequest
 
     config.rack_cas.server_url = 'https://login.umd.edu/cas'
     config.rack_cas.session_store = RackCAS::ActiveRecordStore
-  
+
+    # Autoload first subdirectory in "app/models/" directory
+    config.autoload_paths += Dir[Rails.root.join('app', 'models', '*/')]
   end
 end


### PR DESCRIPTION
Pinned axlsx version to 2.0.1, as that more closely matches what was in
v1.2.0 (which used v2.0.0).

Unpinned rubyzip version, as axlsx needs it to be "~> 1.0.0".

Pinned "roo" version to 1.13.2, as that matches what was in v1.2.0.

Added subdirectories of "app/models" directory to the autoload path. This
was needed for the "report" tests to find the "report" models.

https://issues.umd.edu/browse/LIBITD-999