### PR TITLE
LIBITD-1005. Pinned "pg" gem to v0.18.4

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '4.2.6'
 gem 'sprockets-es6'
 
 # Use sqlite3 as the database for Active Record
-gem 'pg', group: :production
+gem 'pg', '= 0.18.4',  group: :production
 gem 'sqlite3'
 
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,7 +187,7 @@ GEM
     parallel (1.12.0)
     parser (2.4.0.0)
       ast (~> 2.2)
-    pg (0.21.0)
+    pg (0.18.4)
     poltergeist (1.16.0)
       capybara (~> 2.1)
       cliver (~> 0.3.1)
@@ -357,7 +357,7 @@ DEPENDENCIES
   minitest-reporters
   mocha
   money-rails (~> 1)
-  pg
+  pg (= 0.18.4)
   poltergeist
   pry-rails
   pundit


### PR DESCRIPTION
The Annual Staffing Request application is currently using
Postgres v8.4, and v0.18.4 is the last version of the
"pg" gem that supported Postgres v8.4.

This should fix the following warnings which were seen when running
database Rake tasks on the "dev" server:

```
> rake db:migrate RAILS_ENV=production
The PGconn, PGresult, and PGError constants are deprecated, and will be
removed as of version 1.0.

You should use PG::Connection, PG::Result, and PG::Error instead, respectively.

Called from /apps/services/annual-staffing-request/vendor/bundle/ruby/2.2.0/gems/activerecord-4.2.6/lib/active_record/connection_adapters/postgresql_adapter.rb:44:in `new'
```

https://issues.umd.edu/browse/LIBITD-1005