### PR TITLE
LIBITD-1002. Restored "ping" controller for Icinga network monitoring

### DIFF
--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,0 +1,14 @@
+# Controller for Icinga network monitoring to use to determine whether the
+# application is running.
+class PingController < ApplicationController
+  # Controller actions should be accessible without requiring authenication.
+  skip_before_action :ensure_auth
+
+  def verify
+    if ActiveRecord::Base.connected?
+      render text: 'Application is OK'
+    else
+      render text: 'Cannot connect to database!', status: :service_unavailable
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,4 +17,6 @@ Rails.application.routes.draw do
 
   resources :reports
   get '/reports/:id/download' => 'reports#download', as: :report_download
+
+  get '/ping' => 'ping#verify'
 end

--- a/test/controllers/ping_controller_test.rb
+++ b/test/controllers/ping_controller_test.rb
@@ -1,0 +1,11 @@
+require 'test_helper'
+
+class PingControllerTest < ActionController::TestCase
+  test 'ping service can be accessed without logging in' do
+    # Verify that no user is logged in.
+    assert session[:cas].nil?
+
+    get :verify
+    assert_response(:success)
+  end
+end


### PR DESCRIPTION
The "ping" controller provides a "/ping" resource that Icinga can
access without having to perform CAS authentication to verify that the
application is running.

https://issues.umd.edu/browse/LIBITD-1002