### PR TITLE
LIBITD-994 Move a couple of constants into the concern

### DIFF
--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -5,6 +5,11 @@
 #rubocop:disable all
 module Resettable
   extend ActiveSupport::Concern
+  
+  # this is used to generate the organization's associated icon
+  TYPE_MAPPING = { 'root' => 'queen', 'division' => 'bishop', 'department' => 'knight', 'unit' => 'pawn' }.freeze
+  # fields that cna't be changed if there are records in teh archive
+  UNEDITABLE_IF_ARCHIVED = %w[organization_id name code organization_type].freeze
 
   class_methods do
     def reset_counters(id, *counters)

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -13,11 +13,6 @@ class Organization < ApplicationRecord
     end
   end
 
-  # this is used to generate the organization's associated icon
-  TYPE_MAPPING = { 'root' => 'queen', 'division' => 'bishop', 'department' => 'knight', 'unit' => 'pawn' }.freeze
-  # fields that cna't be changed if there are records in teh archive
-  UNEDITABLE_IF_ARCHIVED = %w[organization_id name code organization_type].freeze
-
   belongs_to :parent, class_name: 'Organization', foreign_key: 'organization_id'
   validates :organization_id, presence: true, unless: :root?
 


### PR DESCRIPTION
The way the class loading was working out on the db:migrate it was
resetting some constants when it lazy loaded the Organization class. This moves the
constants into the concern, so those pesky warning messages should go
away.

https://issues.umd.edu/browse/LIBITD-994