### PR TITLE
LIBITD-1004 Make sure justification length is enfored request edits

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem 'rails', '4.2.6'
 gem 'sprockets-es6'
 
 # Use sqlite3 as the database for Active Record
-gem 'pg', '= 0.18.4',  group: :production
+gem 'pg', '= 0.18.4', group: :production
 gem 'sqlite3'
 
 # Use SCSS for stylesheets

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -83,7 +83,7 @@ class Request < ApplicationRecord
   validates :justification, presence: true
   validate :new_justifications_cant_be_long
   def new_justifications_cant_be_long
-    return if review_status && review_status.code !=  'UnderReview'
+    return if self.class.name =~ /^Archive/
     return if justification && justification.split(/\s+/).length < 126
     errors.add(:justification, 'Must be 125 words or less')
   end

--- a/test/models/labor_request_test.rb
+++ b/test/models/labor_request_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+# Tests for the "User" model
+class LaborRequestTest < ActiveSupport::TestCase
+  def setup
+    @request = LaborRequest.where('unit_id IS NOT NULL').first
+  end
+
+  test 'justifcation length should be less than 125 words (unless its archived)' do
+    assert @request.valid?
+    @request.justification = ' word ' * 126
+    refute @request.valid?
+
+    archived = ArchivedLaborRequest.first
+    assert archived.valid?
+    archived.justification = ' word ' * 126
+    assert archived.valid?
+  end
+end


### PR DESCRIPTION
Previously the justification length validation was set to only be
checked during save, not edit ( in case there are existing records
created prior to the new rule ). This changes it to check all records
except Archived records.

https://issues.umd.edu/browse/LIBITD-1004