### PR TITLE
LIBITD-1024 Use 'forward year' for tagging Fiscal Year

### DIFF
--- a/config/initializers/fiscali.rb
+++ b/config/initializers/fiscali.rb
@@ -1,1 +1,2 @@
 Date.fiscal_zone = :us
+Date.use_forward_year!


### PR DESCRIPTION
When archiving records, we want to use the 'forward year' ( eg. fiscal
year 2017-2018 == FY18 )

https://issues.umd.edu/browse/LIBITD-1024