### PR TITLE
LIBITD-1016 Make "required" hover use tooltip

### DIFF
--- a/app/assets/javascripts/app.es6
+++ b/app/assets/javascripts/app.es6
@@ -12,6 +12,7 @@ class App {
       new UnitSelector();
       new WordLimit();
       new Spawner();
+      new RequireTooltip();
   }) 
 
   }

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -26,3 +26,4 @@
 //= require unit_selector 
 //= require word_limit 
 //= require spawner
+//= require require_tooltip

--- a/app/assets/javascripts/require_tooltip.es6
+++ b/app/assets/javascripts/require_tooltip.es6
@@ -1,0 +1,9 @@
+class RequireTooltip {
+
+  constructor(){ this.init(); }
+
+  init() { 
+    $('label.required').tooltip({ title: "REQUIRED" })  
+  }
+
+}


### PR DESCRIPTION
This makes the required label hover use the BS tooltip, rather than
html5.

https://issues.umd.edu/browse/LIBITD-1016