### PR TITLE
LIBITD-1065 Set the default screensize for chromedriver

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -52,7 +52,7 @@ require 'capybara-screenshot/minitest'
 
 Capybara.register_driver :chrome do |app|
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[ --window-size=1500,768] }
+    chromeOptions: { args: %w[--window-size=1500,768] }
   )
   Capybara::Selenium::Driver.new(app, browser: :chrome,
                                       desired_capabilities: caps)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -51,12 +51,16 @@ require 'capybara/minitest'
 require 'capybara-screenshot/minitest'
 
 Capybara.register_driver :chrome do |app|
-  Capybara::Selenium::Driver.new(app, browser: :chrome)
+  caps = Selenium::WebDriver::Remote::Capabilities.chrome(
+    chromeOptions: { args: %w[ --window-size=1500,768] }
+  )
+  Capybara::Selenium::Driver.new(app, browser: :chrome,
+                                      desired_capabilities: caps)
 end
 
 Capybara.register_driver :headless_chrome do |app|
   caps = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w[headless disable-gpu] }
+    chromeOptions: { args: %w[headless disable-gpu window-size=1500,768] }
   )
 
   Capybara::Selenium::Driver.new(app, browser: :chrome,
@@ -77,7 +81,6 @@ class ActionDispatch::IntegrationTest
 
   def use_chrome!
     Capybara.current_driver = ENV['SELENIUM_CHROME'] ? :chrome : :headless_chrome
-    Capybara.page.driver.browser.manage.window.resize_to 1500, 800
   end
 
   def teardown


### PR DESCRIPTION
It looks like some platforms ( i.e. Jenkins ) don't like the resize method, so this moves
the default screensize to an argument passed directly to chromedriver on
initialization.

https://issues.umd.edu/browse/LIBITD-1065