### PR TITLE
LIBITD-1081 Allow unit users to edit unit records

### DIFF
--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -8,14 +8,15 @@ class RequestPolicy < ApplicationPolicy
   end
 
   def show?
-    @user.admin? || @user.all_organizations.map(&:id).include?(@record.organization_id)
+    @user.admin? ||
+      (@user.active_organizations.map(&:id) && [@record.organization_id, @record.unit_id]).any?
   end
 
   def edit?
     return false if @record.archived_proxy?
     return true if @user.admin?
     return false if @record.cutoff?
-    @user.active_organizations.map(&:id).include?(@record.organization_id)
+    (@user.active_organizations.map(&:id) && [@record.organization_id, @record.unit_id]).any?
   end
 
   def update?

--- a/test/policies/request_policy_scope_test.rb
+++ b/test/policies/request_policy_scope_test.rb
@@ -55,6 +55,9 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
+          refute r.cutoff?
+          assert Pundit.policy!(temp_user, r).show?
+          assert Pundit.policy!(temp_user, r).edit?
           assert_equal unit.code, r.unit.code
         end
       end
@@ -71,8 +74,9 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
-          assert_includes [d1.code, d2.code],
-                          r.organization.code
+          assert_includes [d1.code, d2.code], r.organization.code
+          assert Pundit.policy!(temp_user, r).show?
+          assert Pundit.policy!(temp_user, r).edit?
         end
       end
     end
@@ -88,6 +92,8 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
+          assert Pundit.policy!(temp_user, r).show?
+          assert Pundit.policy!(temp_user, r).edit?
           if r.organization == d # it's linked to it's department
             assert_equal d.code, r.organization.code
           else


### PR DESCRIPTION
Request policy was not checking the unit id of the record for user
permissions on the edit permissions check. We should check if the user
has an organization id that's either the records organization_id or
unit_id.

https://issues.umd.edu/browse/LIBITD-1081

LIBITD-1081 Ensure policy show is set for unit user

(cherry picked from commit c6fbe855beaed40469e0f8cb55e29bee5b15a662)