### PR TITLE
LIBITD-1278. Updated Rubocop and fixed offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,13 +4,11 @@ Rails:
 
 # Exclude auto-generated files
 AllCops:
-  Include:
-    - '**/*.axlsx'
-    - '**/Gemfile'
-    - '**/Guardfile'
-    - '**/Rakefile'
   Exclude:
-    - 'bin/*'
+    - 'config.ru'
+    - 'Rakefile'
+    - 'bin/**/*'
+    - 'config/**/*'
     - 'config/initializers/*'
     - 'config/application.rb'
     - 'db/schema.rb'
@@ -18,7 +16,7 @@ AllCops:
     - 'lib/**/*'
     - 'db/seeds.rb'
 
-  TargetRubyVersion: 2.2
+  TargetRubyVersion: 2.5
   TargetRailsVersion: 4.2
 
 Metrics/AbcSize:
@@ -35,7 +33,7 @@ Metrics/LineLength:
 Metrics/ClassLength:
   Exclude:
     - 'test/**/*'
-  
+
 Metrics/BlockLength:
   Exclude:
     - 'test/**/*'
@@ -58,7 +56,7 @@ Style/Documentation:
 Style/ClassVars:
   Exclude:
     - 'test/**/*'
-  
+
 Style/ClassAndModuleChildren:
   Exclude:
     - 'test/**/*'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # use HTTPS for github repos (see https://bundler.io/git.html#security)

--- a/Gemfile
+++ b/Gemfile
@@ -89,7 +89,7 @@ group :test do
   gem 'test_after_commit'
 
   # Code analysis tools
-  gem 'rubocop', '= 0.49.1', require: false
+  gem 'rubocop', '= 0.59.2', require: false
   gem 'rubocop-checkstyle_formatter', require: false
   gem 'simplecov', require: false
   gem 'simplecov-rcov', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -123,6 +123,7 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     io-like (0.3.0)
+    jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
@@ -239,8 +240,7 @@ GEM
       activesupport (= 4.2.10)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rainbow (2.2.2)
-      rake
+    rainbow (3.0.0)
     rake (12.3.1)
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
@@ -250,11 +250,12 @@ GEM
       nokogiri
       rubyzip
       spreadsheet (> 0.6.4)
-    rubocop (0.49.1)
+    rubocop (0.59.2)
+      jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
-      parser (>= 2.3.3.1, < 3.0)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
     rubocop-checkstyle_formatter (0.4.0)
@@ -372,7 +373,7 @@ DEPENDENCIES
   rails (= 4.2.10)
   rb-fsevent
   roo (= 1.13.2)
-  rubocop (= 0.49.1)
+  rubocop (= 0.59.2)
   rubocop-checkstyle_formatter
   ruby_dep (~> 1.3.1)
   rubyzip

--- a/Guardfile
+++ b/Guardfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A sample Guardfile
 # More info at https://github.com/guard/guard#readme
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/app/controllers/concerns/personnel_request_controller.rb
+++ b/app/controllers/concerns/personnel_request_controller.rb
@@ -39,7 +39,7 @@ module PersonnelRequestController
 
   def new
     authorize @model_klass
-    @request ||= @model_klass.new
+    @request ||= @model_klass.new # rubocop:disable Naming/MemoizedInstanceVariableName
   end
 
   def edit

--- a/app/controllers/concerns/personnel_request_controller.rb
+++ b/app/controllers/concerns/personnel_request_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module PersonnelRequestController
   extend ActiveSupport::Concern
   include RequestHelper

--- a/app/controllers/contractor_requests_controller.rb
+++ b/app/controllers/contractor_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ContractorRequestsController < ApplicationController
   include PersonnelRequestController
 

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class HomeController < ApplicationController
   include PersonnelRequestController
 

--- a/app/controllers/impersonate_controller.rb
+++ b/app/controllers/impersonate_controller.rb
@@ -35,6 +35,7 @@ class ImpersonateController < ApplicationController
     # Stops impersonation
     def revert_impersonate
       return if session[IMPERSONATE_USER_PARAM].nil?
+
       clear_current_user
       impersonated_user = current_user
       session[IMPERSONATE_USER_PARAM] = nil

--- a/app/controllers/impersonate_controller.rb
+++ b/app/controllers/impersonate_controller.rb
@@ -4,7 +4,7 @@ class ImpersonateController < ApplicationController
   after_action :verify_authorized, only: :create
 
   # Session parameter name for impersonation id
-  IMPERSONATE_USER_PARAM = 'impersonate_user_id'.freeze
+  IMPERSONATE_USER_PARAM = 'impersonate_user_id'
 
   # GET /impersonate/user/123
   def create

--- a/app/controllers/impersonate_controller.rb
+++ b/app/controllers/impersonate_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ImpersonateController < ApplicationController
   after_action :verify_authorized, only: :create
 

--- a/app/controllers/labor_requests_controller.rb
+++ b/app/controllers/labor_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LaborRequestsController < ApplicationController
   include PersonnelRequestController
 

--- a/app/controllers/links_controller.rb
+++ b/app/controllers/links_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LinksController < ApplicationController
   before_action :set_link, only: %i[show edit update destroy]
   after_action :verify_authorized

--- a/app/controllers/organization_cutoffs_controller.rb
+++ b/app/controllers/organization_cutoffs_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganizationCutoffsController < ApplicationController
   after_action :verify_authorized
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OrganizationsController < ApplicationController
   after_action :verify_authorized
   rescue_from Pundit::NotAuthorizedError, with: :not_authorized

--- a/app/controllers/ping_controller.rb
+++ b/app/controllers/ping_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Controller for Icinga network monitoring to use to determine whether the
 # application is running.
 class PingController < ApplicationController

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -95,7 +95,7 @@ class ReportsController < ApplicationController
 
     def report_params # rubocop:disable Metrics/MethodLength
       report_parameters_keys = params[:report][:parameters].try(:keys)
-      if report_parameters_keys
+      if report_parameters_keys # rubocop:disable Style/SafeNavigation
         # The following modifies the report_parameters_keys map if any of the
         # keys are actually an array of values (such as might come back from
         # a bunch of checkboxes forming a group).

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -82,10 +82,10 @@ class ReportsController < ApplicationController
     # @error_msg and returns false.
     def delete
       @report.destroy
-      return true
+      true
     rescue ActiveRecord::DeleteRestrictionError
       @error_msg = 'Request type cannot be removed as it is used by other records.'
-      return false
+      false
     end
 
     # Use callbacks to share common setup or constraints between actions.

--- a/app/controllers/reports_controller.rb
+++ b/app/controllers/reports_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReportsController < ApplicationController
   before_action :set_report, only: %i[show edit update destroy download]
   after_action :verify_authorized, only: %i[index show create destroy download]

--- a/app/controllers/review_statuses_controller.rb
+++ b/app/controllers/review_statuses_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReviewStatusesController < ApplicationController
   before_action :set_review_status, only: %i[show edit update destroy]
   after_action :verify_authorized

--- a/app/controllers/staff_requests_controller.rb
+++ b/app/controllers/staff_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class StaffRequestsController < ApplicationController
   include PersonnelRequestController
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UsersController < ApplicationController
   before_action :set_user, only: %i[show edit update destroy]
   after_action :verify_authorized, except: :logout

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   # helper to toggle asc and desc ( for ordering )
   def switch_direction(direction)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -79,8 +79,9 @@ module ApplicationHelper
 
   def sorted?
     params[:sort].present?
-  end # A view helper to make sure archived records point to the correct
+  end
 
+  # A view helper to make sure archived records point to the correct route
   def edit_path(object)
     if object.class.name == 'Request'
       method = "edit_#{object.request_model_type.underscore}_request_path".intern

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@
 module ApplicationHelper
   # helper to toggle asc and desc ( for ordering )
   def switch_direction(direction)
-    direction =~ /asc$/ ? [direction.gsub(/asc$/, 'desc'), 'arrow-up'] : [direction.gsub(/desc$/, 'asc'), 'arrow-down']
+    direction.match?(/asc$/) ? [direction.gsub(/asc$/, 'desc'), 'arrow-up'] : [direction.gsub(/desc$/, 'asc'), 'arrow-down']
   end
 
   SORT_MAP = { hourly_rate: :hourly_rate_cents,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,7 +3,7 @@
 module ApplicationHelper
   # helper to toggle asc and desc ( for ordering )
   def switch_direction(direction)
-    direction.match?(/asc$/) ? [direction.gsub(/asc$/, 'desc'), 'arrow-up'] : [direction.gsub(/desc$/, 'asc'), 'arrow-down']
+    direction.match?(/asc$/) ? [direction.gsub(/asc$/, 'desc'), 'arrow-up'] : [direction.gsub(/desc$/, 'asc'), 'arrow-down'] # rubocop:disable Metrics/LineLength
   end
 
   SORT_MAP = { hourly_rate: :hourly_rate_cents,

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -23,7 +23,7 @@ module ApplicationHelper
     SORT_MAP.with_indifferent_access[column] || column
   end
 
-  def multi_sort_link(column, title, direction = 'arrow-up')
+  def multi_sort_link(column, title, direction = 'arrow-up') # rubocop:disable Metrics/AbcSize
     # first we extract any existing sorts in the params
     attrs = Array.wrap(params[:sort]).compact
 

--- a/app/helpers/cas_helper.rb
+++ b/app/helpers/cas_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Provides CAS Authentication and whitelist authorization
 module CasHelper
   def fix_cas_session

--- a/app/helpers/cas_helper.rb
+++ b/app/helpers/cas_helper.rb
@@ -5,6 +5,7 @@ module CasHelper
   def fix_cas_session
     session[:cas] ||= HashWithIndifferentAccess.new
     return if session[:cas].is_a?(HashWithIndifferentAccess)
+
     session[:cas] = session[:cas].with_indifferent_access
   end
 

--- a/app/helpers/cas_helper.rb
+++ b/app/helpers/cas_helper.rb
@@ -11,10 +11,10 @@ module CasHelper
 
   def ensure_auth
     if session[:cas].nil? || session[:cas][:user].nil?
-      render status: 401, text: 'Redirecting to SSO...'
+      render status: :unauthorized, text: 'Redirecting to SSO...'
     else
       update_current_user(User.find_by(cas_directory_id: session[:cas][:user]))
-      render status: 403, text: 'Unrecognized user' unless @current_user
+      render status: :forbidden, text: 'Unrecognized user' unless @current_user
     end
     nil
   end

--- a/app/helpers/reports_helper.rb
+++ b/app/helpers/reports_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ReportsHelper
   def report_formats(report)
     (report.class.formats & Report.formats.keys)

--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RequestHelper
   # Calls the field on the record and attempts to display it.
   # If there is special formatting on the field, define a "render_FIELD_NAME"

--- a/app/helpers/xlsx_helper.rb
+++ b/app/helpers/xlsx_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module XlsxHelper
   def field_widths(fields)
     fields.map { |field| LENGTHY_FIELDS.include?(field) ? 30 : nil }

--- a/app/inputs/color_input.rb
+++ b/app/inputs/color_input.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # defines a color picker input for simple form
 class ColorInput < SimpleForm::Inputs::Base
   def input(wrapper_options)

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -9,7 +9,7 @@ class ReportJob < ActiveJob::Base
     reports.each do |report|
       run_report(report)
     rescue => e
-      report.update_attributes status: 'error'
+      report.update_attributes status: 'error' # rubocop:disable Rails/ActiveRecordAliases
       raise e
     end
   end
@@ -32,8 +32,8 @@ class ReportJob < ActiveJob::Base
                                                                 created_at: report.created_at })
       report.update! status: 'completed', output: output
     else
-      report.update_attributes status: 'error'
-      report.update_attributes status_message: r.error_message
+      report.update_attributes status: 'error' # rubocop:disable Rails/ActiveRecordAliases
+      report.update_attributes status_message: r.error_message # rubocop:disable Rails/ActiveRecordAliases
     end
   end
   # rubocop:enable Metrics/AbcSize, Metrics/MethodLength

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -8,7 +8,7 @@ class ReportJob < ActiveJob::Base
   def perform(*reports)
     reports.each do |report|
       run_report(report)
-    rescue => e
+    rescue => e # rubocop:disable Style/RescueStandardError
       report.update_attributes status: 'error' # rubocop:disable Rails/ActiveRecordAliases
       raise e
     end

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -7,12 +7,10 @@ class ReportJob < ActiveJob::Base
   # The method used to run the report by rails.
   def perform(*reports)
     reports.each do |report|
-      begin
-        run_report(report)
-      rescue => e
-        report.update_attributes status: 'error'
-        raise e
-      end
+      run_report(report)
+    rescue => e
+      report.update_attributes status: 'error'
+      raise e
     end
   end
 

--- a/app/jobs/report_job.rb
+++ b/app/jobs/report_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A job to submit reports and run in background
 class ReportJob < ActiveJob::Base
   queue_as :default

--- a/app/models/archived_contractor_request.rb
+++ b/app/models/archived_contractor_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ArchivedContractorRequest < ContractorRequest
   self.table_name = 'archived_requests'
   class << self

--- a/app/models/archived_labor_request.rb
+++ b/app/models/archived_labor_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ArchivedLaborRequest < LaborRequest
   self.table_name = 'archived_requests'
   class << self

--- a/app/models/archived_request.rb
+++ b/app/models/archived_request.rb
@@ -13,7 +13,7 @@ class ArchivedRequest < ApplicationRecord
 
   belongs_to :review_status, counter_cache: true
   belongs_to :organization, required: true, counter_cache: true
-  belongs_to :unit, class_name: 'Organization', foreign_key: :unit_id
+  belongs_to :unit, class_name: 'Organization', foreign_key: :unit_id, inverse_of: :archived_unit_requests
   belongs_to :user
 
   def current_table_name

--- a/app/models/archived_request.rb
+++ b/app/models/archived_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A Request that has been moved to the archived table
 # This is a generic classs used for certain functions. Most of the time,
 # archived records will be cast as ArchivedLaborRequest and whatnot, which

--- a/app/models/archived_staff_request.rb
+++ b/app/models/archived_staff_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ArchivedStaffRequest < StaffRequest
   self.table_name = 'archived_requests'
   class << self

--- a/app/models/concerns/cutoffable.rb
+++ b/app/models/concerns/cutoffable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cutoffable
   extend ActiveSupport::Concern
 

--- a/app/models/concerns/flattenable.rb
+++ b/app/models/concerns/flattenable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # a mixin to add ability for organization to express themselves as flat trees
 module Flattenable
   extend ActiveSupport::Concern

--- a/app/models/concerns/flattenable.rb
+++ b/app/models/concerns/flattenable.rb
@@ -21,7 +21,7 @@ module Flattenable
 
   included do
     def flat_tree_description
-      prefix = ''.dup
+      prefix = +''
       org_parent = parent
       while org_parent
         prefix << '--'

--- a/app/models/concerns/flattenable.rb
+++ b/app/models/concerns/flattenable.rb
@@ -9,9 +9,7 @@ module Flattenable
     def flat_tree
       child_mapper = lambda do |tree, node|
         tree << node
-        unless node.children.empty?
-          tree += node.children.reduce([], &child_mapper)
-        end
+        tree += node.children.reduce([], &child_mapper) unless node.children.empty?
         return tree.flatten
       end
       includes(children: { children: [:children] })

--- a/app/models/concerns/flattenable.rb
+++ b/app/models/concerns/flattenable.rb
@@ -21,7 +21,7 @@ module Flattenable
 
   included do
     def flat_tree_description
-      prefix = ''
+      prefix = ''.dup
       org_parent = parent
       while org_parent
         prefix << '--'

--- a/app/models/concerns/reportable.rb
+++ b/app/models/concerns/reportable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Generic for all report type objects.
 #
 # Including this in your report adds common functionality and registers it in

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A place for the class methods added to the request modle ( because the cop
 # doesn't like the length of the class :/ )
 module Requestable

--- a/app/models/concerns/requestable.rb
+++ b/app/models/concerns/requestable.rb
@@ -4,8 +4,8 @@
 # doesn't like the length of the class :/ )
 module Requestable
   extend ActiveSupport::Concern
-  # rubocop:disable Metrics/BlockLength
-  class_methods do
+
+  class_methods do # rubocop:disable Metrics/BlockLength
     def policy_class
       RequestPolicy
     end

--- a/app/models/concerns/resettable.rb
+++ b/app/models/concerns/resettable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this just patchs rails reset_counters methods to work with the monkey
 # business we're doing with our associations
 # disabling rubocop...this is taken from Rails core.
@@ -5,7 +7,7 @@
 #rubocop:disable all
 module Resettable
   extend ActiveSupport::Concern
-  
+
   # this is used to generate the organization's associated icon
   TYPE_MAPPING = { 'root' => 'queen', 'division' => 'bishop', 'department' => 'knight', 'unit' => 'pawn' }.freeze
   # fields that cna't be changed if there are records in teh archive

--- a/app/models/contractor_request.rb
+++ b/app/models/contractor_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A Contractor Request
 class ContractorRequest < Request
   VALID_EMPLOYEE_TYPES = ['Contingent 2', 'Contract Faculty'].freeze

--- a/app/models/fiscal_year.rb
+++ b/app/models/fiscal_year.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # this is a convience class to format the fiscal year
 class FiscalYear
   class << self

--- a/app/models/labor_request.rb
+++ b/app/models/labor_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A Labor and Assistance staffing request
 class LaborRequest < Request
   VALID_EMPLOYEE_TYPES = ['Contingent 1', 'Faculty Hourly', 'Student'].freeze

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Admins can record review status of a request
 class Link < ApplicationRecord
   class << self

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -16,21 +16,23 @@ class Organization < ApplicationRecord
     end
   end
 
-  belongs_to :parent, class_name: 'Organization', foreign_key: 'organization_id'
+  belongs_to :parent, class_name: 'Organization', foreign_key: 'organization_id', inverse_of: :children
   validates :organization_id, presence: true, unless: :root?
 
-  has_many :children, foreign_key: :organization_id, class_name: 'Organization'
+  has_many :children, foreign_key: :organization_id, class_name: 'Organization', inverse_of: :parent
   # a more basic AR way of getting children
   has_many :organizations
 
-  has_one :organization_cutoff, foreign_key: :organization_type, primary_key: :organization_type
+  has_one :organization_cutoff, foreign_key: :organization_type, primary_key: :organization_type,
+                                inverse_of: :organizations
 
   has_many :requests, dependent: :restrict_with_error
   has_many :archived_requests, dependent: :restrict_with_error
 
-  has_many :unit_requests, dependent: :restrict_with_error, class_name: 'Request', foreign_key: :unit_id
+  has_many :unit_requests, dependent: :restrict_with_error, class_name: 'Request', foreign_key: :unit_id,
+                           inverse_of: :unit
   has_many :archived_unit_requests, dependent: :restrict_with_error,
-                                    class_name: 'ArchivedRequest', foreign_key: :unit_id
+                                    class_name: 'ArchivedRequest', foreign_key: :unit_id, inverse_of: :unit
 
   def requests_count
     unit? ? unit_requests.count : attributes['requests_count']

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -75,9 +75,9 @@ class Organization < ApplicationRecord
 
   def archived_records?
     if organization_type == 'unit'
-      ArchivedRequest.where(unit_id: id).count > 0
+      ArchivedRequest.where(unit_id: id).count.positive?
     else
-      archived_requests_count > 0
+      archived_requests_count.positive?
     end
   end
 

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -19,12 +19,15 @@ class Organization < ApplicationRecord
   belongs_to :parent, class_name: 'Organization', foreign_key: 'organization_id', inverse_of: :children
   validates :organization_id, presence: true, unless: :root?
 
-  has_many :children, foreign_key: :organization_id, class_name: 'Organization', inverse_of: :parent
+  has_many :children, foreign_key: :organization_id, class_name: 'Organization', inverse_of: :parent,
+                      dependent: :restrict_with_error
   # a more basic AR way of getting children
-  has_many :organizations
+  has_many :organizations, dependent: :restrict_with_error
 
+  # rubocop:disable Rails/HasManyOrHasOneDependent - not sure what the right value is here
   has_one :organization_cutoff, foreign_key: :organization_type, primary_key: :organization_type,
                                 inverse_of: :organizations
+  # rubocop:enable Rails/HasManyOrHasOneDependent
 
   has_many :requests, dependent: :restrict_with_error
   has_many :archived_requests, dependent: :restrict_with_error

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The Organization the the request is associated to
 class Organization < ApplicationRecord
   include Cutoffable

--- a/app/models/organization.rb
+++ b/app/models/organization.rb
@@ -53,8 +53,10 @@ class Organization < ApplicationRecord
   # this makes sure we only have one root record
   def only_one_root
     return if organization_type != 'root'
+
     org =  Organization.find_by(organization_type: Organization.organization_types[:root])
     return if org.nil? || org.id == id
+
     errors.add(:organization_type, 'There can be only one root')
   end
 
@@ -64,6 +66,7 @@ class Organization < ApplicationRecord
     return unless persisted?
     return unless archived_records?
     return if uneditable.empty?
+
     uneditable.each do |k|
       msg = "#{description} has #{archived_requests.count} in the archive. Editing #{k} is not allowed."
       errors.add(k.intern, msg)
@@ -80,6 +83,7 @@ class Organization < ApplicationRecord
 
   def cutoff?
     return false unless organization_cutoff
+
     Time.zone.today > organization_cutoff.cutoff_date
   end
 

--- a/app/models/organization_cutoff.rb
+++ b/app/models/organization_cutoff.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # The Cutoff date tied to a organization type
 # A bit of AR trickery here. The primary_key for this model
 # is the organization_type, which we are reusing the enum from the

--- a/app/models/organization_cutoff.rb
+++ b/app/models/organization_cutoff.rb
@@ -14,7 +14,8 @@ class OrganizationCutoff < ApplicationRecord
 
   self.primary_key = :organization_type
 
-  has_many :organizations, foreign_key: :organization_type, primary_key: :organization_type
+  has_many :organizations, foreign_key: :organization_type, primary_key: :organization_type,
+                           inverse_of: :organization_cutoff
 
   def humanize
     cutoff_date.strftime('%F')

--- a/app/models/organization_cutoff.rb
+++ b/app/models/organization_cutoff.rb
@@ -15,7 +15,7 @@ class OrganizationCutoff < ApplicationRecord
   self.primary_key = :organization_type
 
   has_many :organizations, foreign_key: :organization_type, primary_key: :organization_type,
-                           inverse_of: :organization_cutoff
+                           inverse_of: :organization_cutoff, dependent: :restrict_with_exception
 
   def humanize
     cutoff_date.strftime('%F')

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A basic generic report to be run
 class Report < ActiveRecord::Base
   belongs_to :user

--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -35,8 +35,6 @@ class Report < ActiveRecord::Base
   # registers the available reports
   class Manager
     class << self
-      attr_accessor :reports, :allowed_parameters
-
       # Add the report to our list of registered reports...
       def register_report(klass)
         @reports ||= []

--- a/app/models/reports/contractor_requests_cost_summary_report.rb
+++ b/app/models/reports/contractor_requests_cost_summary_report.rb
@@ -27,7 +27,7 @@ class ContractorRequestsCostSummaryReport
   end
 
   def parameters_valid?
-    valid = parameters && parameters.key?(:review_status_ids)
+    valid = parameters&.key?(:review_status_ids)
     return true if valid
 
     @error_message = 'At least one review status must be specified!'

--- a/app/models/reports/contractor_requests_cost_summary_report.rb
+++ b/app/models/reports/contractor_requests_cost_summary_report.rb
@@ -45,7 +45,7 @@ class ContractorRequestsCostSummaryReport
     allowed_review_status_ids = parameters[:review_status_ids]
     allowed_review_statuses = allowed_review_status_ids.map { |id| ReviewStatus.find(id) }
 
-    ContractorRequest.includes(:organization, :review_status).each do |request|
+    ContractorRequest.includes(:organization, :review_status).find_each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
 

--- a/app/models/reports/contractor_requests_cost_summary_report.rb
+++ b/app/models/reports/contractor_requests_cost_summary_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 # A summary report for the costs of Salaried Contractor requests
 class ContractorRequestsCostSummaryReport

--- a/app/models/reports/contractor_requests_cost_summary_report.rb
+++ b/app/models/reports/contractor_requests_cost_summary_report.rb
@@ -48,6 +48,7 @@ class ContractorRequestsCostSummaryReport
     ContractorRequest.includes(:organization, :review_status).each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
+
       employee_type = request.employee_type
       department_code = request.organization.code
       key = [department_code, employee_type]

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -48,6 +48,7 @@ class LaborRequestsCostSummaryReport
     LaborRequest.includes(:organization, :review_status).each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
+
       employee_type = request.employee_type
       department_code = request.organization.code
       key = [department_code, employee_type]

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -45,7 +45,7 @@ class LaborRequestsCostSummaryReport
     allowed_review_status_ids = parameters[:review_status_ids]
     allowed_review_statuses = allowed_review_status_ids.map { |id| ReviewStatus.find(id) }
 
-    LaborRequest.includes(:organization, :review_status).each do |request|
+    LaborRequest.includes(:organization, :review_status).find_each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
 

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -27,7 +27,7 @@ class LaborRequestsCostSummaryReport
   end
 
   def parameters_valid?
-    valid = parameters && parameters.key?(:review_status_ids)
+    valid = parameters&.key?(:review_status_ids)
     return true if valid
 
     @error_message = 'At least one review status must be specified!'

--- a/app/models/reports/labor_requests_cost_summary_report.rb
+++ b/app/models/reports/labor_requests_cost_summary_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 # A summary report for the costs of Labor and Assistance requests
 class LaborRequestsCostSummaryReport

--- a/app/models/reports/requests_by_department_report.rb
+++ b/app/models/reports/requests_by_department_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 
 # A basic report that just gets all the request types

--- a/app/models/reports/requests_by_type_report.rb
+++ b/app/models/reports/requests_by_type_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 
 # A basic report that just gets all the request types

--- a/app/models/reports/requests_count_by_review_status_report.rb
+++ b/app/models/reports/requests_count_by_review_status_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 # A summary report for the requests count by review status
 class RequestsCountByReviewStatusReport

--- a/app/models/reports/staff_requests_cost_summary_report.rb
+++ b/app/models/reports/staff_requests_cost_summary_report.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'reportable'
 # A summary report for the costs of Staff requests
 class StaffRequestsCostSummaryReport

--- a/app/models/reports/staff_requests_cost_summary_report.rb
+++ b/app/models/reports/staff_requests_cost_summary_report.rb
@@ -27,7 +27,7 @@ class StaffRequestsCostSummaryReport
   end
 
   def parameters_valid?
-    valid = parameters && parameters.key?(:review_status_ids)
+    valid = parameters&.key?(:review_status_ids)
     return true if valid
 
     @error_message = 'At least one review status must be specified!'

--- a/app/models/reports/staff_requests_cost_summary_report.rb
+++ b/app/models/reports/staff_requests_cost_summary_report.rb
@@ -48,6 +48,7 @@ class StaffRequestsCostSummaryReport
     StaffRequest.includes(:organization, :review_status).each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
+
       employee_type = request.employee_type
       department_code = request.organization.code
       key = [department_code, employee_type]

--- a/app/models/reports/staff_requests_cost_summary_report.rb
+++ b/app/models/reports/staff_requests_cost_summary_report.rb
@@ -45,7 +45,7 @@ class StaffRequestsCostSummaryReport
     allowed_review_status_ids = parameters[:review_status_ids]
     allowed_review_statuses = allowed_review_status_ids.map { |id| ReviewStatus.find(id) }
 
-    StaffRequest.includes(:organization, :review_status).each do |request|
+    StaffRequest.includes(:organization, :review_status).find_each do |request|
       review_status = request.review_status
       next unless allowed_review_statuses.include?(review_status)
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -31,7 +31,7 @@ class Request < ApplicationRecord
                        'Pay Adjustment - Reclass': 7, 'Pay Adjustment - Stipend': 8 }
   belongs_to :review_status, counter_cache: true
   belongs_to :organization, required: true, counter_cache: true
-  belongs_to :unit, class_name: 'Organization', foreign_key: :unit_id, counter_cache: true
+  belongs_to :unit, class_name: 'Organization', foreign_key: :unit_id, counter_cache: true, inverse_of: :unit_requests
 
   has_one :division, class_name: 'Organization', through: :organization, source: :parent
 

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This is the base line model for Request that is used by all other
 # request types
 class Request < ApplicationRecord

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -77,11 +77,11 @@ class Request < ApplicationRecord
 
   # method to call the fields expressed in .fields
   def call_field(field)
-    field.to_s.split('__').inject(self) { |a, e| a.send(e) unless a.nil? }
+    field.to_s.split('__').inject(self) { |a, e| a&.send(e) }
   end
 
   def cutoff?
-    persisted? ? (organization && organization.cutoff?) : false
+    persisted? ? (organization&.cutoff?) : false
   end
 
   def source_class

--- a/app/models/request.rb
+++ b/app/models/request.rb
@@ -11,6 +11,7 @@ class Request < ApplicationRecord
   attr_accessor :spawned
   def spawned?
     return false unless spawned
+
     truths = [true, 1, '1', 't', 'T', 'true', 'TRUE'].to_set
     truths.include?(spawned)
   end
@@ -43,6 +44,7 @@ class Request < ApplicationRecord
   validate :org_must_be_dept
   def org_must_be_dept
     return if organization && organization.organization_type == 'department'
+
     errors.add(:organization, 'Must have a department specified.')
   end
 
@@ -50,6 +52,7 @@ class Request < ApplicationRecord
   def unit_must_be_in_dept
     return if unit.nil?
     return if unit.parent == organization
+
     errors.add(:unit, 'Unit must be in the department.')
   end
 
@@ -58,6 +61,7 @@ class Request < ApplicationRecord
   def new_justifications_cant_be_long
     return if self.class.name =~ /^Archive/
     return if justification && justification.split(/\s+/).length < 126
+
     errors.add(:justification, 'Must be 125 words or less')
   end
 
@@ -67,6 +71,7 @@ class Request < ApplicationRecord
 
   after_initialize(lambda do
     return if has_attribute?(:review_status_id) && review_status_id
+
     self.review_status = ReviewStatus.find_by(code: 'UnderReview')
   end)
 
@@ -90,6 +95,7 @@ class Request < ApplicationRecord
   # this casts the record as its source type
   def to_source_proxy
     return self unless self.class.name =~ /^Archive/
+
     attrs = attributes.slice(*source_class.attribute_names).merge(archived_proxy: true,
                                                                   archived_fiscal_year: fiscal_year)
     source_class.new(attrs)

--- a/app/models/review_status.rb
+++ b/app/models/review_status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Admins can record review status of a request
 class ReviewStatus < ApplicationRecord
   validates :name, presence: true

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Role < ApplicationRecord
   class << self
     def policy_class

--- a/app/models/staff_request.rb
+++ b/app/models/staff_request.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # A Labor and Assistance staffing request
 class StaffRequest < Request
   VALID_EMPLOYEE_TYPES = ['Exempt', 'Faculty', 'Graduate Assistant', 'Non-exempt'].freeze

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative 'organization'
 
 class User < ApplicationRecord

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,7 @@ class User < ApplicationRecord
   def organization_mapper(only_active = true)
     lambda do |org|
       return [] if !org.active? && only_active
+
       active_children = [org]
       child_mapper = lambda do |child|
         active_children << child unless child.deactivated?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ApplicationRecord
   accepts_nested_attributes_for :roles, reject_if: :all_blank, allow_destroy: true
 
   has_many :organizations, through: :roles
-  has_many :requests
+  has_many :requests, dependent: :restrict_with_exception
 
   default_scope(lambda do
     includes(roles: { organization: { organization_cutoff: [], children: { children: [:children] } } })

--- a/app/policies/admin_only_policy.rb
+++ b/app/policies/admin_only_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Policy that only allows users with Admin role to perform any function
 class AdminOnlyPolicy < ApplicationPolicy
   def index?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/app/policies/archived_request_policy.rb
+++ b/app/policies/archived_request_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ArchivedRequestPolicy < RequestPolicy
   def create?
     false

--- a/app/policies/report_policy.rb
+++ b/app/policies/report_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Policy for making and viewing reports
 class ReportPolicy < AdminOnlyPolicy
   def edit?

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -3,6 +3,7 @@
 class RequestPolicy < ApplicationPolicy
   def create?
     return true if @user.admin? || @record.is_a?(Class)
+
     check_unit!
     (@user.active_organizations.map(&:id) & [@record.organization_id, @record.unit_id]).any?
   end
@@ -19,6 +20,7 @@ class RequestPolicy < ApplicationPolicy
   def edit?
     return false if @record.archived_proxy?
     return true if @user.admin?
+
     (@user.active_organizations.map(&:id) & [@record.organization_id, @record.unit_id]).any?
   end
 

--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RequestPolicy < ApplicationPolicy
   def create?
     return true if @user.admin? || @record.is_a?(Class)

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Policy that only allows users to see and edit their own User entry
 class UserPolicy < AdminOnlyPolicy
   def show?

--- a/app/views/requests/index.xlsx.axlsx
+++ b/app/views/requests/index.xlsx.axlsx
@@ -6,7 +6,7 @@ worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [klass.name]
 wb = xlsx_package.workbook
 
 record_set.each_with_index do |records, i|
-  name = worksheets[i] ? worksheets[i] : worksheets.first
+  name = worksheets[i] || worksheets.first
   wb.add_worksheet(name: name.pluralize) do |sheet|
     defined_styles = wb.define_styles
     first_column_style, first_column_width = nil

--- a/app/views/requests/index.xlsx.axlsx
+++ b/app/views/requests/index.xlsx.axlsx
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 record_set = Array.wrap(record_set)
 worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [klass.name]
 

--- a/app/views/shared/contractor_requests_cost_summary.axlsx
+++ b/app/views/shared/contractor_requests_cost_summary.axlsx
@@ -161,6 +161,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -169,6 +170,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   default_col_width = 16
@@ -293,6 +295,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/contractor_requests_cost_summary.axlsx
+++ b/app/views/shared/contractor_requests_cost_summary.axlsx
@@ -45,7 +45,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 def construct_division_worksheet(wb, styles, record_set, division, created_at)
   default_col_width = 16
   # Division Worksheet Construction
@@ -161,7 +161,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -170,7 +170,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   default_col_width = 16
@@ -295,7 +295,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/contractor_requests_cost_summary.axlsx
+++ b/app/views/shared/contractor_requests_cost_summary.axlsx
@@ -73,6 +73,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     data_start_row = row_num
     data.each do |record|
       next unless record[:division] == division
+
       sheet.add_row [record[:department],
                      record[:c2],
                      record[:cfac],

--- a/app/views/shared/contractor_requests_cost_summary.axlsx
+++ b/app/views/shared/contractor_requests_cost_summary.axlsx
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @return [String] a "safe" cell name for uses with the Axlsx gem by removing
 #    spaces and underscores from the given name.
 def axls_safe_cell_name(name)

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -45,7 +45,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 def construct_division_worksheet(wb, styles, record_set, division, created_at)
   # Division Worksheet Construction
   wb.add_worksheet(name: axls_safe_cell_name(division)) do |sheet| # rubocop:disable Metrics/BlockLength
@@ -168,7 +168,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -177,7 +177,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   wb.insert_worksheet(0, name: 'Summary_L_and_A') do |sheet| # rubocop:disable Metrics/BlockLength
@@ -310,7 +310,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -168,6 +168,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -176,6 +177,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   wb.insert_worksheet(0, name: 'Summary_L_and_A') do |sheet| # rubocop:disable Metrics/BlockLength
@@ -308,6 +310,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -72,6 +72,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     data_start_row = row_num
     data.each do |record|
       next unless record[:division] == division
+
       sheet.add_row [record[:department],
                      record[:c1],
                      record[:hourly_faculty],

--- a/app/views/shared/labor_requests_cost_summary.axlsx
+++ b/app/views/shared/labor_requests_cost_summary.axlsx
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @return [String] a "safe" cell name for uses with the Axlsx gem by removing
 #    spaces and underscores from the given name.
 def axls_safe_cell_name(name)

--- a/app/views/shared/requests_count_review_status.axlsx
+++ b/app/views/shared/requests_count_review_status.axlsx
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# rubocop:disable Metrics/AbcSize,Metrics/MethodLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 def construct_summary_worksheet(wb, styles, record_set)
   # Requests Count Worksheet Construction
   wb.add_worksheet(name: 'Requests Count by Review Status') do |sheet| # rubocop:disable Metrics/BlockLength
@@ -49,7 +49,7 @@ def construct_summary_worksheet(wb, styles, record_set)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize,Metrics/MethodLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 
 wb = xlsx_package.workbook
 

--- a/app/views/shared/requests_count_review_status.axlsx
+++ b/app/views/shared/requests_count_review_status.axlsx
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # rubocop:disable Metrics/AbcSize,Metrics/MethodLength
 def construct_summary_worksheet(wb, styles, record_set)
   # Requests Count Worksheet Construction

--- a/app/views/shared/staff_requests_cost_summary.axlsx
+++ b/app/views/shared/staff_requests_cost_summary.axlsx
@@ -73,6 +73,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     data_start_row = row_num
     data.each do |record|
       next unless record[:division] == division
+
       sheet.add_row [record[:department],
                      record[:fac],
                      record[:ga],

--- a/app/views/shared/staff_requests_cost_summary.axlsx
+++ b/app/views/shared/staff_requests_cost_summary.axlsx
@@ -45,7 +45,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 def construct_division_worksheet(wb, styles, record_set, division, created_at)
   default_col_width = 16
   # Division Worksheet Construction
@@ -180,7 +180,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength, Naming/UncommunicativeMethodParamName
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -189,7 +189,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
-# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   default_col_width = 16
@@ -333,7 +333,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
-# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Naming/UncommunicativeMethodParamName
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/staff_requests_cost_summary.axlsx
+++ b/app/views/shared/staff_requests_cost_summary.axlsx
@@ -180,6 +180,7 @@ def construct_division_worksheet(wb, styles, record_set, division, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 # Constructs a summary worksheet, inserting it at the front of the workbook.
 #
@@ -188,6 +189,7 @@ end
 # @param record_set [Hash] the data to use
 # @param division [Division] the division to use
 # @param created_at [ActiveSupport::TimeWithZone] the report creation time
+# rubocop:disable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 def construct_summary_worksheet(wb, styles, record_set, created_at)
   # Summary Worksheet Construction
   default_col_width = 16
@@ -331,6 +333,7 @@ def construct_summary_worksheet(wb, styles, record_set, created_at)
     row_num += 1
   end
 end
+# rubocop:enable Metrics/AbcSize, Metrics/MethodLength, Metrics/LineLength
 
 wb = xlsx_package.workbook
 styles = wb.define_styles

--- a/app/views/shared/staff_requests_cost_summary.axlsx
+++ b/app/views/shared/staff_requests_cost_summary.axlsx
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # @return [String] a "safe" cell name for uses with the Axlsx gem by removing
 #    spaces and underscores from the given name.
 def axls_safe_cell_name(name)

--- a/test/controllers/contractor_requests_controller_test.rb
+++ b/test/controllers/contractor_requests_controller_test.rb
@@ -108,7 +108,7 @@ class ContractorRequestsControllerTest < ActionController::TestCase
       not_unit = Organization.where(
         organization_type: Organization.organization_types['unit']
       ).where.not(id: unit).first
-      refute_equal unit, not_unit
+      assert_not_equal unit, not_unit
       assert_no_difference('Request.count') do
         post :create, contractor_request: {
           contractor_name: @contractor_request.contractor_name,

--- a/test/controllers/contractor_requests_controller_test.rb
+++ b/test/controllers/contractor_requests_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ContractorRequestsControllerTest < ActionController::TestCase

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class HomeControllerTest < ActionController::TestCase

--- a/test/controllers/impersonate_controller_test.rb
+++ b/test/controllers/impersonate_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ImpersonateControllerTest < ActionController::TestCase

--- a/test/controllers/labor_requests_controller_test.rb
+++ b/test/controllers/labor_requests_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LaborRequestsControllerTest < ActionController::TestCase

--- a/test/controllers/links_controller_test.rb
+++ b/test/controllers/links_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class LinksControllerTest < ActionController::TestCase

--- a/test/controllers/organization_cutoffs_controller_test.rb
+++ b/test/controllers/organization_cutoffs_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class OrganizationCutoffsControllerTest < ActionController::TestCase

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class OrganizationsControllerTest < ActionController::TestCase

--- a/test/controllers/organizations_controller_test.rb
+++ b/test/controllers/organizations_controller_test.rb
@@ -44,7 +44,7 @@ class OrganizationsControllerTest < ActionController::TestCase
     patch :update, id: @organization, organization: {
       code: @organization.code, organization_id: @organization.parent, name: @organization.name
     }
-    assert !flash.empty?
+    assert_not flash.empty?
     assert_redirected_to organizations_path
   end
 
@@ -63,7 +63,7 @@ class OrganizationsControllerTest < ActionController::TestCase
     assert_no_difference('Organization.count') do
       delete :destroy, id: @organization
     end
-    assert !flash.empty?
+    assert_not flash.empty?
 
     assert_redirected_to organizations_path
   end

--- a/test/controllers/ping_controller_test.rb
+++ b/test/controllers/ping_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class PingControllerTest < ActionController::TestCase

--- a/test/controllers/reports_controller_test.rb
+++ b/test/controllers/reports_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReportsControllerTest < ActionController::TestCase

--- a/test/controllers/review_statuses_controller_test.rb
+++ b/test/controllers/review_statuses_controller_test.rb
@@ -68,7 +68,7 @@ class ReviewStatusesControllerTest < ActionController::TestCase
     assert_no_difference('ReviewStatus.count') do
       delete :destroy, id: @review_status
     end
-    assert !flash.empty?
+    assert_not flash.empty?
 
     assert_redirected_to review_statuses_path
   end

--- a/test/controllers/review_statuses_controller_test.rb
+++ b/test/controllers/review_statuses_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReviewStatusesControllerTest < ActionController::TestCase

--- a/test/controllers/staff_requests_controller_test.rb
+++ b/test/controllers/staff_requests_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class StaffRequestsControllerTest < ActionController::TestCase

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UsersControllerTest < ActionController::TestCase

--- a/test/integration/department_user_test.rb
+++ b/test/integration/department_user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class DepartmentUserTest < ActionDispatch::IntegrationTest

--- a/test/integration/department_user_test.rb
+++ b/test/integration/department_user_test.rb
@@ -28,7 +28,7 @@ class DepartmentUserTest < ActionDispatch::IntegrationTest
     find('.page-header .btn-success').click
 
     assert page.has_content?('Labor and Assistance Requests successfully created.')
-    refute page.has_content?('Unit is required for users with only Unit permissions')
+    assert_not page.has_content?('Unit is required for users with only Unit permissions')
   end
 
   test 'should allow department user to make a unit request even if past unit deadline' do
@@ -54,7 +54,7 @@ class DepartmentUserTest < ActionDispatch::IntegrationTest
     find('.page-header .btn-success').click
 
     assert page.has_content?('Labor and Assistance Requests successfully created.')
-    refute page.has_content?('Unit is required for users with only Unit permissions')
-    refute page.has_content?('The submission window for this request has ended.')
+    assert_not page.has_content?('Unit is required for users with only Unit permissions')
+    assert_not page.has_content?('The submission window for this request has ended.')
   end
 end

--- a/test/integration/index_view_test.rb
+++ b/test/integration/index_view_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class IndexViewTest < ActionDispatch::IntegrationTest

--- a/test/integration/index_view_test.rb
+++ b/test/integration/index_view_test.rb
@@ -22,6 +22,6 @@ class IndexViewTest < ActionDispatch::IntegrationTest
 
     assert current_url == url
     assert page.has_content? name
-    refute find('table').text.include? name
+    assert_not find('table').text.include? name
   end
 end

--- a/test/integration/organization_edit_test.rb
+++ b/test/integration/organization_edit_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class OrganizationEditTest < ActionDispatch::IntegrationTest

--- a/test/integration/organization_edit_test.rb
+++ b/test/integration/organization_edit_test.rb
@@ -20,9 +20,9 @@ class OrganizationEditTest < ActionDispatch::IntegrationTest
 
     # when we visit the nonedit page these links should not be there
     visit current_url.gsub('/edit', '')
-    refute page.has_link?('Add Member')
-    refute page.has_button?('Active')
-    refute page.has_button?('Deactive')
-    refute page.has_selector?('input[type=submit]:not([disabled])')
+    assert_not page.has_link?('Add Member')
+    assert_not page.has_button?('Active')
+    assert_not page.has_button?('Deactive')
+    assert_not page.has_selector?('input[type=submit]:not([disabled])')
   end
 end

--- a/test/integration/read_only_form_test.rb
+++ b/test/integration/read_only_form_test.rb
@@ -25,7 +25,7 @@ class ReadOnlyFormTest < ActionDispatch::IntegrationTest
     fill_in 'Position title', with: SecureRandom.hex
     find('.page-header .btn-success').click
     assert page.has_content?('Labor and Assistance Requests successfully created.')
-    refute page.has_selector?('.help_block')
+    assert_not page.has_selector?('.help_block')
   end
 
   test 'should not have help messages on archive form' do
@@ -34,6 +34,6 @@ class ReadOnlyFormTest < ActionDispatch::IntegrationTest
     click_link 'View Archive'
     first(:link, 'Details').click
     assert page.has_content?('The submission is in the archive associated to FY')
-    refute page.has_selector?('.help_block')
+    assert_not page.has_selector?('.help_block')
   end
 end

--- a/test/integration/read_only_form_test.rb
+++ b/test/integration/read_only_form_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class ReadOnlyFormTest < ActionDispatch::IntegrationTest

--- a/test/integration/unit_user_test.rb
+++ b/test/integration/unit_user_test.rb
@@ -27,14 +27,14 @@ class UnitUserTest < ActionDispatch::IntegrationTest
     fill_in 'Position title', with: SecureRandom.hex
     find('.page-header .btn-success').click
 
-    refute page.has_content?('Labor and Assistance Requests successfully created.')
+    assert_not page.has_content?('Labor and Assistance Requests successfully created.')
     assert page.has_content?('Unit is required for users with only Unit permissions')
 
     select @unit.name, from: 'Unit'
     find('.page-footer .btn-success').click
 
     assert page.has_content?('Labor and Assistance Requests successfully created.')
-    refute page.has_content?('Unit is required for users with only Unit permissions')
+    assert_not page.has_content?('Unit is required for users with only Unit permissions')
   end
 
   test 'should require a unit if the user is a unit user when editing' do
@@ -64,7 +64,7 @@ class UnitUserTest < ActionDispatch::IntegrationTest
     select '', from: 'Unit'
     find('.page-footer .btn-success').click
 
-    refute page.has_content?("#{position_title} successfully updated.")
+    assert_not page.has_content?("#{position_title} successfully updated.")
     assert page.has_content?('Unit is required for users with only Unit permissions')
   end
 
@@ -109,7 +109,7 @@ class UnitUserTest < ActionDispatch::IntegrationTest
     fill_in 'Position title', with: position_title
     find('.page-footer .btn-success').click
 
-    refute page.has_content?('Labor and Assistance Requests successfully created.')
+    assert_not page.has_content?('Labor and Assistance Requests successfully created.')
     assert page.has_content?('Unit is required for users with only Unit permissions')
   end
 end

--- a/test/integration/unit_user_test.rb
+++ b/test/integration/unit_user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class UnitUserTest < ActionDispatch::IntegrationTest

--- a/test/integration/word_count_test.rb
+++ b/test/integration/word_count_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class WordCountTest < ActionDispatch::IntegrationTest

--- a/test/models/fiscal_year_test.rb
+++ b/test/models/fiscal_year_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "User" model

--- a/test/models/labor_request_test.rb
+++ b/test/models/labor_request_test.rb
@@ -12,13 +12,13 @@ class LaborRequestTest < ActiveSupport::TestCase
     assert @request.valid?
     @request.unit = Organization.where('organization_id IS NOT ?', @request.organization.id)
                                 .where(organization_type: Organization.organization_types['unit']).first
-    refute @request.valid?
+    assert_not @request.valid?
   end
 
   test 'justifcation length should be less than 125 words (unless its archived)' do
     assert @request.valid?
     @request.justification = ' word ' * 126
-    refute @request.valid?
+    assert_not @request.valid?
 
     archived = ArchivedLaborRequest.first
     assert archived.valid?

--- a/test/models/labor_request_test.rb
+++ b/test/models/labor_request_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "User" model

--- a/test/models/link_test.rb
+++ b/test/models/link_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "User" model

--- a/test/models/organization_test.rb
+++ b/test/models/organization_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "Organization" model

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "Report" model

--- a/test/models/report_test.rb
+++ b/test/models/report_test.rb
@@ -43,7 +43,7 @@ class ReportTest < ActiveSupport::TestCase
     class ::CrazyReport; end
     @report = reports(:report_completed)
     @report.manager.register_report(CrazyReport)
-    refute_includes(@report.manager.reports, 'crazy_report')
+    assert_not_includes(@report.manager.reports, 'crazy_report')
   end
 
   test 'should return an instance of a report when manager is asked' do

--- a/test/models/reports/contractor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/contractor_requests_cost_summary_report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests Contractor Requests Cost Summary report

--- a/test/models/reports/contractor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/contractor_requests_cost_summary_report_test.rb
@@ -53,8 +53,8 @@ class ContractorRequestsCostSummaryReportTest < ActiveSupport::TestCase
       actual_other_support_total += datum[:other_support]
     end
 
-    assert actual_annual_base_pay_total.cents > 0
-    assert actual_other_support_total.cents > 0
+    assert actual_annual_base_pay_total.cents.positive?
+    assert actual_other_support_total.cents.positive?
     assert_equal expected_annual_base_pay_total, actual_annual_base_pay_total
     assert_equal expected_other_support_total, actual_other_support_total
   end

--- a/test/models/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/labor_requests_cost_summary_report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests Labor Requests Cost Summary report

--- a/test/models/reports/labor_requests_cost_summary_report_test.rb
+++ b/test/models/reports/labor_requests_cost_summary_report_test.rb
@@ -54,8 +54,8 @@ class LaborRequestsCostSummaryReportTest < ActiveSupport::TestCase
       actual_other_support_total += datum[:other_support]
     end
 
-    assert actual_annual_cost_total.cents > 0
-    assert actual_other_support_total.cents > 0
+    assert actual_annual_cost_total.cents.positive?
+    assert actual_other_support_total.cents.positive?
     assert_equal expected_annual_cost_total, actual_annual_cost_total
     assert_equal expected_other_support_total, actual_other_support_total
   end

--- a/test/models/reports/requests_by_department_report_test.rb
+++ b/test/models/reports/requests_by_department_report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests Requests By Department report

--- a/test/models/reports/requests_count_by_review_status_report_test.rb
+++ b/test/models/reports/requests_count_by_review_status_report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests Requests Counts By Review Status report

--- a/test/models/reports/staff_requests_cost_summary_report_test.rb
+++ b/test/models/reports/staff_requests_cost_summary_report_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests Staff Requests Cost Summary report

--- a/test/models/reports/staff_requests_cost_summary_report_test.rb
+++ b/test/models/reports/staff_requests_cost_summary_report_test.rb
@@ -55,8 +55,8 @@ class StaffRequestsCostSummaryReportTest < ActiveSupport::TestCase
       actual_other_support_total += datum[:other_support]
     end
 
-    assert actual_annual_base_pay_total.cents > 0
-    assert actual_other_support_total.cents > 0
+    assert actual_annual_base_pay_total.cents.positive?
+    assert actual_other_support_total.cents.positive?
     assert_equal expected_annual_base_pay_total, actual_annual_base_pay_total
     assert_equal expected_other_support_total, actual_other_support_total
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for the "User" model

--- a/test/policies/admin_only_policy_test.rb
+++ b/test/policies/admin_only_policy_test.rb
@@ -12,36 +12,36 @@ class AdminOnlyPolicyTest < ActiveSupport::TestCase
   # In the following the "Role" object is used to get the AdminOnlyPolicy
   def test_index
     assert Pundit.policy!(@admin_user, Role).index?
-    refute Pundit.policy!(@not_admin_user, Role).index?
+    assert_not Pundit.policy!(@not_admin_user, Role).index?
   end
 
   def test_show
     assert Pundit.policy!(@admin_user, Role).show?
-    refute Pundit.policy!(@not_admin_user, Role).show?
+    assert_not Pundit.policy!(@not_admin_user, Role).show?
   end
 
   def test_new
     assert Pundit.policy!(@admin_user, Role).new?
-    refute Pundit.policy!(@not_admin_user, Role).new?
+    assert_not Pundit.policy!(@not_admin_user, Role).new?
   end
 
   def test_edit
     assert Pundit.policy!(@admin_user, Role).edit?
-    refute Pundit.policy!(@not_admin_user, Role).edit?
+    assert_not Pundit.policy!(@not_admin_user, Role).edit?
   end
 
   def test_create
     assert Pundit.policy!(@admin_user, Role).create?
-    refute Pundit.policy!(@not_admin_user, Role).create?
+    assert_not Pundit.policy!(@not_admin_user, Role).create?
   end
 
   def test_update
     assert Pundit.policy!(@admin_user, Role).update?
-    refute Pundit.policy!(@not_admin_user, Role).update?
+    assert_not Pundit.policy!(@not_admin_user, Role).update?
   end
 
   def test_destroy
     assert Pundit.policy!(@admin_user, Role).destroy?
-    refute Pundit.policy!(@not_admin_user, Role).destroy?
+    assert_not Pundit.policy!(@not_admin_user, Role).destroy?
   end
 end

--- a/test/policies/admin_only_policy_test.rb
+++ b/test/policies/admin_only_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for AdminOnlyPolicy class

--- a/test/policies/archived_request_policy_test.rb
+++ b/test/policies/archived_request_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for PersonnelRequestPolicy's Scope class

--- a/test/policies/report_policy_test.rb
+++ b/test/policies/report_policy_test.rb
@@ -9,6 +9,6 @@ class ReportPolicyTest < ActiveSupport::TestCase
   end
 
   def test_edit
-    refute Pundit.policy!(@admin_user, Report).edit?
+    assert_not Pundit.policy!(@admin_user, Report).edit?
   end
 end

--- a/test/policies/report_policy_test.rb
+++ b/test/policies/report_policy_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for ReportPolicy class

--- a/test/policies/request_policy_scope_test.rb
+++ b/test/policies/request_policy_scope_test.rb
@@ -57,7 +57,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
-          refute r.cutoff?
+          assert_not r.cutoff?
           assert Pundit.policy!(temp_user, r).show?
           assert Pundit.policy!(temp_user, r).edit?
           assert_equal unit.code, r.unit.code
@@ -82,7 +82,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
         requests.each do |r|
           assert r.unit.cutoff?
           assert Pundit.policy!(temp_user, r).show?
-          refute Pundit.policy!(temp_user, r).edit?
+          assert_not Pundit.policy!(temp_user, r).edit?
           assert_equal unit.code, r.unit.code
         end
       end

--- a/test/policies/request_policy_scope_test.rb
+++ b/test/policies/request_policy_scope_test.rb
@@ -8,7 +8,7 @@ require 'test_helper'
 class RequestPolicyScopeTest < ActiveSupport::TestCase
   test 'personnel requests have records' do
     # Without records, all the rest of the tests are probably meaningless
-    assert Request.count > 0
+    assert Request.count.positive?
   end
 
   test 'user without role cannot see any personnel requests' do
@@ -35,7 +35,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
       contractor_results = Pundit.policy_scope!(temp_user, ContractorRequest)
 
       record_count = labor_results.count + staff_results.count + contractor_results.count
-      assert record_count > 0, "No records found for department '#{department.code}'"
+      assert record_count.positive?, "No records found for department '#{department.code}'"
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
@@ -53,7 +53,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
       contractor_results = Pundit.policy_scope!(temp_user, ContractorRequest)
 
       record_count = labor_results.count + staff_results.count + contractor_results.count
-      assert record_count > 0, "No records found for unit '#{unit.code}'"
+      assert record_count.positive?, "No records found for unit '#{unit.code}'"
 
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
@@ -77,7 +77,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
       staff_results = Pundit.policy_scope!(temp_user, StaffRequest)
       contractor_results = Pundit.policy_scope!(temp_user, ContractorRequest)
       record_count = labor_results.count + staff_results.count + contractor_results.count
-      assert record_count > 0, "No records found for unit '#{unit.code}'"
+      assert record_count.positive?, "No records found for unit '#{unit.code}'"
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
           assert r.unit.cutoff?
@@ -100,7 +100,7 @@ class RequestPolicyScopeTest < ActiveSupport::TestCase
       staff_results = Pundit.policy_scope!(temp_user, StaffRequest)
       contractor_results = Pundit.policy_scope!(temp_user, ContractorRequest)
       record_count = labor_results.count + staff_results.count + contractor_results.count
-      assert record_count > 0, "No records found for unit '#{unit.code}'"
+      assert record_count.positive?, "No records found for unit '#{unit.code}'"
       [labor_results, staff_results, contractor_results].each do |requests|
         requests.each do |r|
           assert Pundit.policy!(temp_user, r).show?

--- a/test/policies/request_policy_scope_test.rb
+++ b/test/policies/request_policy_scope_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 # Tests for PersonnelRequestPolicy's Scope class

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ SimpleCov.formatters = [
 SimpleCov.start 'rails'
 
 ENV['RAILS_ENV'] ||= 'test'
-require File.expand_path('../../config/environment', __FILE__)
+require File.expand_path('../config/environment', __dir__)
 require 'rails/test_help'
 require 'minitest/reporters'
 Minitest::Reporters.use!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,9 +32,8 @@ class ActiveSupport::TestCase
   # Add more helper methods to be used by all tests here...
   def run_as_user(user)
     user = user.cas_directory_id if user.is_a?(User)
-    original_user = if session[:cas] && session[:cas][:user]
-                      session[:cas][:user]
-                    end
+    original_user = session[:cas][:user] if session[:cas] && session[:cas][:user]
+
     session[:cas] = { user: user }
     begin
       yield user

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 require 'simplecov-rcov'
 SimpleCov.formatters = [


### PR DESCRIPTION
Updated Rubocop to latest Rubocop version (0.59.2)

In .rubocop.yml, changed "TargetRubyVersion" parameter to "2.5" so Ruby 2.5 checking would be used.

Fixed offenses found by Rubocop.

https://issues.umd.edu/browse/LIBITD-1278