### PR TITLE
LIBITD-1285. Updated gems to fix security vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -61,11 +61,11 @@ gem 'umd_lib_style', github: 'umd-lib/umd_lib_style', ref: '1.2.0'
 gem 'cocoon'
 gem 'simple_form'
 
-gem 'axlsx', '2.1.0.pre'
+gem 'axlsx', '3.0.0.pre'
 gem 'axlsx_rails'
 gem 'fiscali'
 gem 'money-rails', '~>1'
-gem 'rubyzip', '~> 1.1.0'
+gem 'rubyzip'
 gem 'will_paginate'
 gem 'will_paginate-bootstrap'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,10 +57,11 @@ GEM
       io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
-    axlsx (2.1.0.pre)
-      htmlentities (~> 4.3.1)
-      nokogiri (>= 1.4.1)
-      rubyzip (~> 1.1.7)
+    axlsx (3.0.0.pre)
+      htmlentities (~> 4.3, >= 4.3.4)
+      mimemagic (~> 0.3)
+      nokogiri (~> 1.8, >= 1.8.2)
+      rubyzip (~> 1.2, >= 1.2.1)
     axlsx_rails (0.5.2)
       actionpack (>= 3.1)
       axlsx (>= 2.0.1)
@@ -278,7 +279,7 @@ GEM
       rubocop (>= 0.35.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.3.1)
-    rubyzip (1.1.7)
+    rubyzip (1.2.2)
     sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -355,7 +356,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  axlsx (= 2.1.0.pre)
+  axlsx (= 3.0.0.pre)
   axlsx_rails
   bootsnap (>= 1.1.0)
   bullet
@@ -395,7 +396,7 @@ DEPENDENCIES
   rubocop (= 0.59.2)
   rubocop-checkstyle_formatter
   ruby_dep (~> 1.3.1)
-  rubyzip (~> 1.1.0)
+  rubyzip
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
   selenium-webdriver


### PR DESCRIPTION
Updated the "axlsx" and associated "rubyzip" gem to address
vulnerable version of "rubyzip". Needed to update "axlsx" gem to
"3.0.0.pre" version, because previous version had a gemspec file that
locked rubyzip to v1.1.x.

https://issues.umd.edu/browse/LIBITD-1285