### PR TITLE
LIBITD-1275. Fix Excel formatting for personnel request currency fields

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -53,55 +53,9 @@ module RequestHelper
     fields
   end
 
-  # Returns a list of the formats used for styling export outputs
-  #
-  # @param fields [Array] the fields to generate a list of formats
-  # @return [Array] list of associated formats to the fields
-  def field_formats(fields)
-    fields.map { |field| currency_fields.include?(field) ? :currency : :default }
-  end
-
-  # Returns a list of the widths used for styling export outputs
-  #
-  # @param fields [Array] the fields to generate a list of formats
-  # @return [Array] list of widths to the fields
-  def field_widths(fields)
-    fields.map { |field| lengthy_fields.include?(field) ? 30 : nil }
-  end
-
-  # Returns a list of fields for a record and a list of formats for those
-  # fields
-  #
-  # @param klass [Class] the active record klass being displayed
-  # @param show_all [Boolean] option to include all fields in class
-  # @return [Array] the list of fields being displayed
-  # @return [Array] the list of formats to be displayed
-  def fields_and_formats_and_widths(klass, show_all = false)
-    fields = fields(klass, show_all)
-    formats = field_formats(fields)
-    widths = field_widths(fields)
-    [fields, formats, widths]
-  end
-
-  # Just return the currency fields
-  def currency_fields
-    CURRENCY_FIELDS
-  end
-
-  # Just return the lengthy fields
-  def lengthy_fields
-    LENGTHY_FIELDS
-  end
-
-  # these are the fields that we want to render into a currency
-  # since we've added special xlsx formatting, we need to call a special helper
-  # for the excel exports that is _xslx.
+  # Generate methods that renders fields as currency
   CURRENCY_FIELDS.each do |m|
     define_method("render_#{m}".intern) { |r| number_to_currency r.call_field(m.intern) }
-    define_method("render_#{m}_xlsx".intern) do |r|
-      field = r.call_field(m.intern) || BigDecimal(0)
-      humanized_money_with_symbol field
-    end
   end
 
   # Returns an array of the fields used in labor_requests

--- a/app/helpers/xlsx_helper.rb
+++ b/app/helpers/xlsx_helper.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 module XlsxHelper
+  # Returns a list of the widths used for styling export outputs
+  #
+  # @param fields [Array] the fields to generate a list of formats
+  # @return [Array] list of widths to the fields
   def field_widths(fields)
     fields.map { |field| LENGTHY_FIELDS.include?(field) ? 30 : nil }
   end
 
+  # Returns a list of the formats used for styling export outputs
+  #
+  # @param fields [Array] the fields to generate a list of formats
+  # @return [Array] list of associated formats to the fields
   def field_formats(fields)
-    fields.map { |field| CURRENCY_FIELDS.include?(field) ? 30 : nil }
+    fields.map { |field| CURRENCY_FIELDS.include?(field) ? :currency : nil }
   end
 
   def formats_and_widths(fields)
-    [field_widths(fields), field_formats(fields)]
+    [field_formats(fields), field_widths(fields)]
   end
 
   def currency_field?(field)

--- a/app/views/requests/index.xlsx.axlsx
+++ b/app/views/requests/index.xlsx.axlsx
@@ -4,37 +4,38 @@ record_set = Array.wrap(record_set)
 worksheets = klass.respond_to?(:worksheets) ? klass.worksheets : [klass.name]
 
 wb = xlsx_package.workbook
+styles = wb.define_styles
 
 record_set.each_with_index do |records, i|
   name = worksheets[i] || worksheets.first
   wb.add_worksheet(name: name.pluralize) do |sheet|
-    defined_styles = wb.define_styles
-    first_column_style, first_column_width = nil
+    first_column_style = nil
+    first_column_width = nil
 
     sheet_klass = name.constantize
 
     fields = sheet_klass.fields.flat_map { |k| k == :organization__name ? [:division__name, k] : k }
 
-    styles, widths = formats_and_widths(fields)
+    formats, widths = formats_and_widths(fields)
 
     header_row = fields.map { |field| sheet_klass.human_attribute_name(field.to_s.split('__').first.intern) }
-    sheet.add_row ['Request Category'] + header_row, style: defined_styles[:header_bottom_border]
+    sheet.add_row ['Request Category'] + header_row, style: styles[:header_bottom_border]
     records.each do |record|
       data = [record.class.name.underscore.humanize] + fields.map do |field|
-        # for currency fields we need to call the special xlsx view helper
         if currency_field?(field.intern)
+          # for currency fields we need to specify the "xlsx" format, because
+          # otherwise we'll get the currency formatting used for the HTML pages,
+          # which confuses Excel
           call_record_field record, field, :xlsx
-        # otherwise we want all the view helpers called
         else
+          # otherwise we want all the view helpers called
           call_record_field record, field
         end
       end
-      styles = [first_column_style] + formats.map do |format|
-        defined_styles[format]
-      end
+      row_styles = [first_column_style] + formats.map { |f| f.nil? ? nil : styles[f] }
       column_widths = [first_column_width] + widths
 
-      sheet.add_row data, style: styles
+      sheet.add_row data, style: row_styles
       sheet.column_widths(*column_widths)
     end
   end

--- a/test/controllers/labor_requests_controller_test.rb
+++ b/test/controllers/labor_requests_controller_test.rb
@@ -179,26 +179,6 @@ class LaborRequestsControllerTest < ActionController::TestCase
       expected_row_count = num_labor_requests + 1 # include header row in count
       assert num_labor_requests > 1, 'There are no labor requests'
       assert_equal expected_row_count, spreadsheet.last_row
-
-      # make sure all the currency columns have $
-      c_header = [
-        'Gift/Other Funds',
-        'Annual cost',
-        'Hourly rate'
-      ]
-      spreadsheet.parse(headers: true)
-      # get the column numbers
-      columns = spreadsheet.headers.to_h
-                           .select { |k, v| c_header.include?(k) ? v : nil }
-                           .values
-      columns.each do |col|
-        # get the values from the column
-        vals = spreadsheet.column(col)
-        vals.shift
-        vals.each do |val|
-          assert_match(/^\$/, val)
-        end
-      end
     ensure
       file.delete
     end


### PR DESCRIPTION
Fixes an issue where the currency fields in the Excel spreadsheet for
exported personnel requests were displaying as a general text field,
instead of a more specific numeric field.

Modified index.xlsx.axlsx to use workbook-defined styles, as in
other Axlsx views.

Modified XlsxHelper to use CURRENCY_FIELDS and LENGTHY_FIELDS constants
directly (as is done in other places in the code), instead of delegating
to methods in the RequestHelper module. Fixed the "field_formats" method
to actually return a format, instead of width. Also flipped the order of
the return values in the "formats_and_widths" method because that was
what seemed to be expected in other parts of the code (and the order
matches the method name).

Removed unused methods in the RequestHelper module
(app/helpers/request_helper.rb), including the generated "xlsx"-specific
methods for currency fields, which are no longer needed.

In labor_requests_controller_test.rb, removed the code that checked for
the "$" because the cell no longer contains a string (it contains a
Float instead). Looked through the Roo methods, but could not find a
way to check the style of the cells.

https://issues.umd.edu/browse/LIBITD-1275