### PR TITLE
LIBITD-1290 Allow edits on new records in policy

### DIFF
--- a/app/policies/request_policy.rb
+++ b/app/policies/request_policy.rb
@@ -18,7 +18,11 @@ class RequestPolicy < ApplicationPolicy
   end
 
   def edit?
+    # archives are never edited
     return false if @record.archived_proxy?
+    # if its a new record, we allow edits..unless the user is out of orgs
+    return true if @record.changed? && !@user.active_organizations.empty?
+    # admin always edits
     return true if @user.admin?
 
     (@user.active_organizations.map(&:id) & [@record.organization_id, @record.unit_id]).any?

--- a/test/system/unit_user_test.rb
+++ b/test/system/unit_user_test.rb
@@ -41,6 +41,8 @@ class UnitUserTest < ApplicationSystemTestCase
     click_link 'Labor and Assistance'
     click_link 'New'
 
+    assert_not page.has_content?('The submission window for this request has ended')
+
     position_title = SecureRandom.hex
 
     select 'Faculty', from: 'Employee type'
@@ -63,6 +65,7 @@ class UnitUserTest < ApplicationSystemTestCase
     select '', from: 'Unit'
     find('.page-footer .btn-success').click
 
+    assert_not page.has_content?('The submission window for this request has ended')
     assert_not page.has_content?("#{position_title} successfully updated.")
     assert page.has_content?('Unit is required for users with only Unit permissions')
   end


### PR DESCRIPTION
The request policy can fail on new records because it's assuming the
record has organizations ( new records do not ). If the record is dirty,
allow editing as long as the user has orgs to use.

https://issues.umd.edu/browse/LIBITD-1290