### PR TITLE
LIBITD-993 Make reports index table sortable

### DIFF
--- a/app/models/report.rb
+++ b/app/models/report.rb
@@ -8,6 +8,7 @@ class Report < ApplicationRecord
 
   # Provides a short human-readable description for this record, for GUI prompts
   alias_attribute :description, :name
+  default_scope { includes(%i[user]) }
 
   enum status: {
     pending: 0,

--- a/app/views/reports/index.html.erb
+++ b/app/views/reports/index.html.erb
@@ -13,11 +13,11 @@
   <table class="table table-striped">
     <thead>
       <tr>
-        <th id="name">Name</th>
-        <th id="format">Format</th>
-        <th id="creator_name">Creator</th>
-        <th id="created_at">Created At</th>
-        <th id="status">Status</th>
+        <th id="name"><%= multi_sort_link( 'reports.name', 'Name', :desc) %></th>
+        <th id="format"><%= multi_sort_link( :format, 'Format', :desc) %></th>
+        <th id="creator_name"><%= multi_sort_link( 'users.name', 'Creator', :desc) %></th>
+        <th id="created_at"><%= multi_sort_link( :created_at, 'Created At', :desc) %></th>
+        <th id="status"><%= multi_sort_link( :status, 'Status', :desc) %></th>
         <th id="download">Output</th>
       </tr>
     </thead>

--- a/test/system/report_index_view_test.rb
+++ b/test/system/report_index_view_test.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class ReportIndexViewTest < ApplicationSystemTestCase
+  def setup
+    login_admin
+  end
+
+  test 'should keep page and sort when deleting' do
+    click_link 'admin'
+    click_link 'Reports'
+
+    headers = all('th')
+    headers.each do |header|
+      header.find('a').click
+    end
+  end
+end


### PR DESCRIPTION
This allows sorting on the reports index table.

https://issues.umd.edu/browse/LIBITD-993