### PR TITLE
LIBITD-1304. Fixed "Reset Sorting" link on "My Requests" page

### DIFF
--- a/app/helpers/request_helper.rb
+++ b/app/helpers/request_helper.rb
@@ -35,7 +35,7 @@ module RequestHelper
 
   def reset_sorts_link
     if @model_klass.name == 'Request'
-      link_to(t('reset_sorting'), '/', class: 'btn btn-link')
+      link_to(t('reset_sorting'), my_requests_path, class: 'btn btn-link')
     elsif sorted?
       link_to(t('reset_sorting'), polymorphic_path(@model_klass.source_class,
                                                    archive: params[:archive]), class: 'btn btn-link')


### PR DESCRIPTION
Fixed an issue in which the "Reset Sorting" link on the "My Requests"
was resetting to the application home page, instead of the "My Request"
page.

Modified the "reset_sorts_link" method in the
app/helpers/request_helper.rb to set the "Reset Sorting Link" to the
"my_requests_path", as the model class appears to be "Request" when the
"My Requests" page is being displayed.

https://issues.umd.edu/browse/LIBITD-1304