### PR TITLE
LIBITD-1306. Centered Cutoff Dates on home page and sorted by date

### DIFF
--- a/app/views/home/show.html.erb
+++ b/app/views/home/show.html.erb
@@ -8,14 +8,22 @@
     <div class="panel-body">
       <ul class="list-group requests-homepage">
         <li class='alert alert-danger'>
-          <h4 class='list-group-item'><b>Cutoff Dates:</b></h4>
-          <ul class='list-group'> 
-            <% OrganizationCutoff.where.not( organization_type: 'root' ).each do |cutoff| %>
-              <li class='list-group-item'>
-                <b><%= cutoff.organization_type.humanize %></b>: <%= cutoff.cutoff_date %>
-            </li>
-            <% end %>
-          </ul>
+          <h4 class='list-group-item' style='text-align: center'><b>Cutoff Dates</b></h4>
+          <div class='list-group-item'>
+            <table class="table-condensed" style="margin: 0px auto;">
+                <% OrganizationCutoff.where.not( organization_type: 'root' ).order(cutoff_date: :asc, organization_type: :desc).each do |cutoff| %>
+                  <tr>
+                    <td>
+                      <strong><%= cutoff.organization_type.humanize %></strong>
+                    </td>
+                    <td>
+                      <%= cutoff.cutoff_date.strftime("%B %e, %Y") %>
+                    </td>
+                  </tr>
+                </li>
+                <% end %>
+            </table>
+          </div>
         </li>
         <li class='alert alert-info'><%= link_to 'Labor and Assistance Requests', polymorphic_url( LaborRequest ), class: "list-group-item btn-link" %>
           <div class="well"><%= t('help_text.labor_request_description') %></div>


### PR DESCRIPTION
Modified the "Cutoff Dates" display on the home page to be centered,
and sorted by cutoff date (and by organization type, in case of a tie).

https://issues.umd.edu/browse/LIBITD-1306