### PR TITLE
LIBITD-1491. Updated to use "webdrivers" gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -96,10 +96,8 @@ end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15'
-  gem 'selenium-webdriver'
-  # Easy installation and use of chromedriver to run system tests with Chrome
-  gem 'chromedriver-helper'
+  gem 'capybara'
+  gem 'webdrivers'
 
   gem 'connection_pool'
   gem 'minitest-reporters'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,11 +50,9 @@ GEM
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
-    addressable (2.5.2)
-      public_suffix (>= 2.0.2, < 4.0)
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
     ansi (1.5.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (9.0.0)
     ast (2.4.0)
     axlsx (3.0.0.pre)
@@ -77,18 +75,15 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11.0)
     byebug (10.0.2)
-    capybara (2.18.0)
+    capybara (3.29.0)
       addressable
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
-    childprocess (0.9.0)
-      ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (2.1.0)
-      archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (~> 1.5)
+      xpath (~> 3.2)
+    childprocess (3.0.0)
     cocoon (1.2.11)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
@@ -103,7 +98,7 @@ GEM
     execjs (2.7.0)
     faker (1.9.1)
       i18n (>= 0.7)
-    ffi (1.9.25)
+    ffi (1.11.3)
     fiscali (2.4.3)
       activesupport
     formatador (0.2.5)
@@ -125,7 +120,6 @@ GEM
     htmlentities (4.3.4)
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
-    io-like (0.3.0)
     jaro_winkler (1.5.1)
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
@@ -152,8 +146,8 @@ GEM
     metaclass (0.0.4)
     method_source (0.9.0)
     mimemagic (0.3.2)
-    mini_mime (1.0.1)
-    mini_portile2 (2.3.0)
+    mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
     minitest-reporters (1.3.5)
       ansi
@@ -176,8 +170,8 @@ GEM
     multi_json (1.13.1)
     nenv (0.3.0)
     nio4r (2.3.1)
-    nokogiri (1.8.5)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.5)
+      mini_portile2 (~> 2.4.0)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -191,11 +185,11 @@ GEM
       method_source (~> 0.9.0)
     pry-rails (0.3.6)
       pry (>= 0.10.4)
-    public_suffix (3.0.3)
+    public_suffix (4.0.1)
     puma (3.12.0)
     pundit (2.0.0)
       activesupport (>= 3.0.0)
-    rack (2.0.5)
+    rack (2.0.7)
     rack-cas (0.16.0)
       addressable (~> 2.3)
       nokogiri (~> 1.5)
@@ -239,6 +233,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
+    regexp_parser (1.6.0)
     roo (2.7.1)
       nokogiri (~> 1)
       rubyzip (~> 1.1, < 2.0.0)
@@ -254,7 +249,7 @@ GEM
       rubocop (>= 0.35.1)
     ruby-progressbar (1.10.0)
     ruby_dep (1.3.1)
-    rubyzip (1.2.2)
+    rubyzip (1.3.0)
     sass (3.6.0)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -269,9 +264,9 @@ GEM
     sdoc (0.4.2)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    selenium-webdriver (3.8.0)
-      childprocess (~> 0.5)
-      rubyzip (~> 1.0)
+    selenium-webdriver (3.142.6)
+      childprocess (>= 0.5, < 4.0)
+      rubyzip (>= 1.2.2)
     shellany (0.0.1)
     shoulda-context (1.2.2)
     shoulda-matchers (3.1.2)
@@ -318,6 +313,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
+    webdrivers (4.1.2)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (>= 3.0, < 4.0)
     websocket-driver (0.7.0)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.3)
@@ -336,8 +335,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bullet
   byebug
-  capybara (>= 2.15)
-  chromedriver-helper
+  capybara
   cocoon
   connection_pool
   dotenv-rails (~> 2.5.0)
@@ -369,7 +367,6 @@ DEPENDENCIES
   rubyzip
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
-  selenium-webdriver
   shoulda-context
   shoulda-matchers (>= 3.0.1)
   simple_form
@@ -384,6 +381,7 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   umd_lib_style!
   web-console (>= 3.3.0)
+  webdrivers
   will_paginate
   will_paginate-bootstrap
 

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -7,14 +7,16 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   # See https://gist.github.com/bbonamin/4b01be9ed5dd1bdaf909462ff4fdca95
   DOWNLOAD_DIR = File.join(Dir.tmpdir, 'downloads')
 
-  options = Selenium::WebDriver::Chrome::Options.new
-  options.add_preference(:download, prompt_for_download: false,
-                                    default_directory: DOWNLOAD_DIR)
+  Capybara.register_driver :chrome_headless do |app|
+    options = ::Selenium::WebDriver::Chrome::Options.new
 
-  Capybara.register_driver :headless_chrome do |app|
     options.add_argument('--headless')
-    options.add_argument('--disable-gpu')
+    options.add_argument('--no-sandbox')
+    options.add_argument('--disable-dev-shm-usage')
     options.add_argument('--window-size=1400,1400')
+
+    options.add_preference(:download, prompt_for_download: false,
+                                      default_directory: DOWNLOAD_DIR)
 
     driver = Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
 
@@ -29,11 +31,10 @@ class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
                                     behavior: 'allow',
                                     downloadPath: DOWNLOAD_DIR
                                   })
-
     driver
   end
 
-  driven_by :headless_chrome, options: options
+  driven_by :chrome_headless
 
   def javascript_errors
     page.driver.browser.manage.logs.get(:browser)


### PR DESCRIPTION
Replaced deprecated "chromedriver-helper" gem with "webdrivers", so that
later versions of Chrome can be used for testing.

Following the example in "student-applications", removed the version
restriction on the "capybara" gem, and updated
the "application_system_test_case.rb" file to more closely match the
same file in "student-applications".

https://issues.umd.edu/browse/LIBITD-1491